### PR TITLE
fix: warning for vue2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "esbuild": "*",
     "rollup": "^3",
     "vite": ">=3",
-    "vue": ">=3.2.13",
+    "vue": ">=2.7 || >=3.2.13",
     "webpack": "^4 || ^5"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### Description

Just fix warning when use vue2.7

### Linked Issues

![image](https://github.com/unplugin/unplugin-turbo-console/assets/23276822/9748d7dc-07dc-4d92-a864-ce86df504765)

