### PR TITLE
feat: auto detect available port

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.1.0",
     "ast-kit": "^0.11.3",
+    "get-port-please": "^3.1.2",
     "h3": "^1.10.0",
     "launch-editor": "^2.6.1",
     "magic-string": "^0.30.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unplugin-turbo-console",
   "type": "module",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "packageManager": "pnpm@8.6.12",
   "description": "Improve the Developer Experience of console.log()",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       esbuild:
         specifier: '*'
         version: 0.19.8
+      get-port-please:
+        specifier: ^3.1.2
+        version: 3.1.2
       h3:
         specifier: ^1.10.0
         version: 1.10.0
@@ -44,7 +47,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.6.2
-        version: 2.6.2(@vue/compiler-sfc@3.3.9)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.0)
+        version: 2.6.2(@vue/compiler-sfc@3.4.13)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.0)
       '@babel/types':
         specifier: ^7.23.6
         version: 7.23.6
@@ -188,7 +191,7 @@ importers:
         version: link:../..
       vue-loader:
         specifier: ^17.2.2
-        version: 17.3.1(@vue/compiler-sfc@3.3.9)(vue@3.2.45)(webpack@5.89.0)
+        version: 17.3.1(@vue/compiler-sfc@3.4.13)(vue@3.2.45)(webpack@5.89.0)
 
   examples/svelte-kit:
     devDependencies:
@@ -280,7 +283,7 @@ importers:
         version: 5.0.8(@vue/cli-service@5.0.8)(esbuild@0.19.8)(eslint@8.56.0)(typescript@4.5.5)(vue@3.3.9)
       '@vue/cli-service':
         specifier: ~5.0.0
-        version: 5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9)
+        version: 5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9)
       typescript:
         specifier: ~4.5.5
         version: 4.5.5
@@ -311,7 +314,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
 
-  /@antfu/eslint-config@2.6.2(@vue/compiler-sfc@3.3.9)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.0):
+  /@antfu/eslint-config@2.6.2(@vue/compiler-sfc@3.4.13)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.0):
     resolution: {integrity: sha512-iHJtFrJLE0gc+oQGxe8I2vpXwhn2wAbz2kqunSPhiOt39yV6yuoE+NJt5nstzy0INKfjSL2teQKlr4g7E2bVhA==}
     hasBin: true
     peerDependencies:
@@ -365,7 +368,7 @@ packages:
       eslint-plugin-vitest: 0.3.20(@typescript-eslint/eslint-plugin@6.18.1)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.0)
       eslint-plugin-vue: 9.19.2(eslint@8.56.0)
       eslint-plugin-yml: 1.11.0(eslint@8.56.0)
-      eslint-processor-vue-blocks: 0.1.1(@vue/compiler-sfc@3.3.9)(eslint@8.56.0)
+      eslint-processor-vue-blocks: 0.1.1(@vue/compiler-sfc@3.4.13)(eslint@8.56.0)
       globals: 13.24.0
       jsonc-eslint-parser: 2.4.0
       local-pkg: 0.5.0
@@ -4642,7 +4645,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.5
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.23.5)(core-js@3.33.3)(vue@3.3.9)
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9)
       '@vue/cli-shared-utils': 5.0.8
       babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.89.0)
       thread-loader: 3.0.4(webpack@5.89.0)
@@ -4663,7 +4666,7 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9)
       '@vue/cli-shared-utils': 5.0.8
     transitivePeerDependencies:
       - encoding
@@ -4685,7 +4688,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.5
       '@types/webpack-env': 1.18.4
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9)
       '@vue/cli-shared-utils': 5.0.8
       babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.89.0)
       fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@4.5.5)(webpack@5.89.0)
@@ -4710,10 +4713,10 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9)
     dev: true
 
-  /@vue/cli-service@5.0.8(@vue/compiler-sfc@3.3.9)(esbuild@0.19.8)(vue@3.3.9):
+  /@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.13)(esbuild@0.19.8)(vue@3.3.9):
     resolution: {integrity: sha512-nV7tYQLe7YsTtzFrfOMIHc5N2hp5lHG2rpYr0aNja9rNljdgcPZLyQRb2YRivTHqTv7lI962UXFURcpStHgyFw==}
     engines: {node: ^12.0.0 || >= 14.0.0}
     hasBin: true
@@ -4753,7 +4756,7 @@ packages:
       '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8)
       '@vue/cli-shared-utils': 5.0.8
       '@vue/component-compiler-utils': 3.3.0
-      '@vue/vue-loader-v15': /vue-loader@15.11.1(@vue/compiler-sfc@3.3.9)(css-loader@6.8.1)(webpack@5.89.0)
+      '@vue/vue-loader-v15': /vue-loader@15.11.1(@vue/compiler-sfc@3.4.13)(css-loader@6.8.1)(webpack@5.89.0)
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.11.2
       acorn-walk: 8.3.0
@@ -4790,7 +4793,7 @@ packages:
       ssri: 8.0.1
       terser-webpack-plugin: 5.3.9(esbuild@0.19.8)(webpack@5.89.0)
       thread-loader: 3.0.4(webpack@5.89.0)
-      vue-loader: 17.3.1(@vue/compiler-sfc@3.3.9)(vue@3.3.9)(webpack@5.89.0)
+      vue-loader: 17.3.1(@vue/compiler-sfc@3.4.13)(vue@3.3.9)(webpack@5.89.0)
       vue-style-loader: 4.1.3
       webpack: 5.89.0(esbuild@0.19.8)
       webpack-bundle-analyzer: 4.10.1
@@ -5178,7 +5181,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.3.9
       '@vue/shared': 3.3.9
-      vue: 3.3.9(typescript@5.2.2)
+      vue: 3.3.9(typescript@5.3.3)
 
   /@vue/server-renderer@3.4.13(vue@3.4.13):
     resolution: {integrity: sha512-hkw+UQyDZZtSn1q30nObMfc8beVEQv2pG08nghigxGw+iOWodR+tWSuJak0mzWAHlP/xt/qLc//dG6igfgvGEA==}
@@ -8186,13 +8189,13 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-processor-vue-blocks@0.1.1(@vue/compiler-sfc@3.3.9)(eslint@8.56.0):
+  /eslint-processor-vue-blocks@0.1.1(@vue/compiler-sfc@3.4.13)(eslint@8.56.0):
     resolution: {integrity: sha512-9+dU5lU881log570oBwpelaJmOfOzSniben7IWEDRYQPPWwlvaV7NhOtsTuUWDqpYT+dtKKWPsgz4OkOi+aZnA==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.3.0
       eslint: ^8.50.0
     dependencies:
-      '@vue/compiler-sfc': 3.3.9
+      '@vue/compiler-sfc': 3.4.13
       eslint: 8.56.0
     dev: true
 
@@ -8820,6 +8823,10 @@ packages:
   /get-port-please@3.1.1:
     resolution: {integrity: sha512-3UBAyM3u4ZBVYDsxOQfJDxEa6XTbpBDrOjp4mf7ExFRt5BKs/QywQQiJsh2B+hxcZLSapWqCRvElUe8DnKcFHA==}
     dev: true
+
+  /get-port-please@3.1.2:
+    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
+    dev: false
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -15562,7 +15569,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.5.0(@types/node@18.19.1)
+      vite: 4.5.0(@types/node@20.11.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -15962,7 +15969,7 @@ packages:
     resolution: {integrity: sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==}
     dev: true
 
-  /vue-loader@15.11.1(@vue/compiler-sfc@3.3.9)(css-loader@6.8.1)(webpack@5.89.0):
+  /vue-loader@15.11.1(@vue/compiler-sfc@3.4.13)(css-loader@6.8.1)(webpack@5.89.0):
     resolution: {integrity: sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.0.8
@@ -15981,7 +15988,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@vue/compiler-sfc': 3.3.9
+      '@vue/compiler-sfc': 3.4.13
       '@vue/component-compiler-utils': 3.3.0
       css-loader: 6.8.1(webpack@5.89.0)
       hash-sum: 1.0.2
@@ -16045,7 +16052,7 @@ packages:
       - whiskers
     dev: true
 
-  /vue-loader@17.3.1(@vue/compiler-sfc@3.3.9)(vue@3.2.45)(webpack@5.89.0):
+  /vue-loader@17.3.1(@vue/compiler-sfc@3.4.13)(vue@3.2.45)(webpack@5.89.0):
     resolution: {integrity: sha512-nmVu7KU8geOyzsStyyaxID/uBGDMS8BkPXb6Lu2SNkMawriIbb+hYrNtgftHMKxOSkjjjTF5OSSwPo3KP59egg==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
@@ -16057,7 +16064,7 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@vue/compiler-sfc': 3.3.9
+      '@vue/compiler-sfc': 3.4.13
       chalk: 4.1.2
       hash-sum: 2.0.0
       vue: 3.2.45
@@ -16065,7 +16072,7 @@ packages:
       webpack: 5.89.0(esbuild@0.19.8)
     dev: true
 
-  /vue-loader@17.3.1(@vue/compiler-sfc@3.3.9)(vue@3.3.9)(webpack@5.89.0):
+  /vue-loader@17.3.1(@vue/compiler-sfc@3.4.13)(vue@3.3.9)(webpack@5.89.0):
     resolution: {integrity: sha512-nmVu7KU8geOyzsStyyaxID/uBGDMS8BkPXb6Lu2SNkMawriIbb+hYrNtgftHMKxOSkjjjTF5OSSwPo3KP59egg==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
@@ -16077,7 +16084,7 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@vue/compiler-sfc': 3.3.9
+      '@vue/compiler-sfc': 3.4.13
       chalk: 4.1.2
       hash-sum: 2.0.0
       vue: 3.3.9(typescript@4.5.5)
@@ -16186,7 +16193,6 @@ packages:
       '@vue/server-renderer': 3.3.9(vue@3.3.9)
       '@vue/shared': 3.3.9
       typescript: 5.3.3
-    dev: true
 
   /vue@3.4.13(typescript@5.3.3):
     resolution: {integrity: sha512-FE3UZ0p+oUZTwz+SzlH/hDFg+XsVRFvwmx0LXjdD1pRK/cO4fu5v6ltAZji4za4IBih3dV78elUK3di8v3pWIg==}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When multiple services that use `unplugin-turbo-console` start at the same time, only the first service can work properly because the launch editor's port is fixed.

Now when the port can auto detect available one.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
