### PR TITLE
feat: oxc parser

### DIFF
--- a/docs/guide/configurations.md
+++ b/docs/guide/configurations.md
@@ -10,7 +10,7 @@
 | disableHighlight      |   `boolean`   | `false` | Wheather to disable [highlight output](/features/highlight) feature |
 | port | `number` | `3070` | Specify the plugin's service port number |
 | extendedPathFileNames | `string[]` | `[]` | [Extended path file names](/features/highlight.html#expand-path-file-name) |
-| babelParserPlugins | `ParserPlugin[]` | `["typescript", "jsx"]` | The incoming value will be automatically merged with the default value. [All babel parser plugins](https://babeljs.io/docs/en/babel-parser#plugins) |
+| <span class="text-yellow-600 font-600">This option has been removed since v1.11.0</span> <br /> ~~babelParserPlugins~~ | `ParserPlugin[]` | `["typescript", "jsx"]` | The incoming value will be automatically merged with the default value. [All babel parser plugins](https://babeljs.io/docs/en/babel-parser#plugins) |
 | disablePassLogs      |   `boolean`   | `false` | Wheather to disable [Pass Logs](/features/pass-logs) feature |
 | silent | `boolean` | `false` | Avoid the plugin's terminal output at project startup |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,29 +31,3 @@ console.log('bar') // turbo-console-disable-line
 console.log('foo')
 console.log('bar')
 ```
-
-## Compilation Syntax Errors
-
-If you use some unstable ECMAScript syntax, you might see errors like the following in the terminal:
-
-```
-[unplugin-turbo-console] Transform src/App.vue error: SyntaxError:
-This experimental syntax requires enabling the parser plugin: "importAttributes". (5:39)
-```
-
-To resolve this, add the missing Babel parser plugin to `babelParserPlugins`:
-
-```js{2,7} twoslash [vite.config.ts]
-import { defineConfig } from 'vite'
-import TurboConsole from 'unplugin-turbo-console/vite'
-
-export default defineConfig({
-  plugins: [
-    TurboConsole({
-      babelParserPlugins: ['importAttributes'],
-    }),
-  ],
-})
-```
-
-> Related [issus](https://github.com/unplugin/unplugin-turbo-console/issues/35)

--- a/docs/zh-CN/guide/configurations.md
+++ b/docs/zh-CN/guide/configurations.md
@@ -10,7 +10,7 @@
 | disableHighlight      |   `boolean`   | `false` | 是否禁用[高亮输出](/zh-CN/features/highlight)功能 |
 | port | `number` | `3070` | 指定插件的服务端口号 |
 | extendedPathFileNames | `string[]` | `[]` | [拓展路径文件名](/zh-CN/features/highlight.html#拓展路径文件名) |
-| babelParserPlugins | `ParserPlugin[]` | `["typescript", "jsx"]` | babel插件，传入的值会与默认值自动合并。[所有插件](https://babeljs.io/docs/en/babel-parser#plugins) |
+| <span class="text-yellow-600 font-600">此选项已于 v1.11.0 移除</span> <br /> ~~babelParserPlugins~~   | `ParserPlugin[]` | `["typescript", "jsx"]` | babel插件，传入的值会与默认值自动合并。[所有插件](https://babeljs.io/docs/en/babel-parser#plugins) |
 | disablePassLogs      |   `boolean`   | `false` | 是否禁用[传递日志](/zh-CN/features/pass-logs)功能 |
 | silent | `boolean` | `false` | 阻止项目启动时插件的终端输出 |
 

--- a/docs/zh-CN/troubleshooting.md
+++ b/docs/zh-CN/troubleshooting.md
@@ -31,29 +31,3 @@ console.log('bar') // turbo-console-disable-line
 console.log('foo')
 console.log('bar')
 ```
-
-## 编译语法错误
-
-如果你使用了一些未稳定的ECMAScript语法，你可能会在终端看到类似错误：
-
-```
-[unplugin-turbo-console] Transform src/App.vue error: SyntaxError:
-This experimental syntax requires enabling the parser plugin: "importAttributes". (5:39)
-```
-
-解决方法是将缺失的 babel parser 插件添加到`babelParserPlugins`中：
-
-```js{2,7} twoslash [vite.config.ts]
-import { defineConfig } from 'vite'
-import TurboConsole from 'unplugin-turbo-console/vite'
-
-export default defineConfig({
-  plugins: [
-    TurboConsole({
-      babelParserPlugins: ['importAttributes'],
-    }),
-  ],
-})
-```
-
-> 相关 [issus](https://github.com/unplugin/unplugin-turbo-console/issues/35)

--- a/examples/vite-vue3/src/App.vue
+++ b/examples/vite-vue3/src/App.vue
@@ -4,6 +4,10 @@ import { logTs } from './tsLog'
 import { server } from 'unplugin-turbo-console/helper'
 
 function logVue() {
+  console.log('from vue')
+}
+
+function serverLog() {
   server.log('from vue')
 }
 </script>
@@ -27,7 +31,7 @@ function logVue() {
   </h2>
 
   <div style="display: flex; gap: 10px;">
-    <button @click="logVue">Client -> Server</button>
+    <button @click="serverLog">Client -> Server</button>
   </div>
 </template>
 

--- a/examples/vite-vue3/src/jsLog.js
+++ b/examples/vite-vue3/src/jsLog.js
@@ -1,4 +1,4 @@
 export function logJs() {
-  console.log('from js')
+  console.log('from js') // turbo-console-disable-line
 }
 

--- a/examples/vite-vue3/src/tsLog.ts
+++ b/examples/vite-vue3/src/tsLog.ts
@@ -1,3 +1,4 @@
 export function logTs() {
-  console.log('from ts')
+  const a = '你好'
+  console.log(a)
 }

--- a/package.json
+++ b/package.json
@@ -157,19 +157,20 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.1.2",
-    "ast-kit": "^1.2.0",
+    "estree-walker": "^3.0.3",
     "get-port-please": "^3.1.2",
     "h3": "1.12.0",
     "launch-editor": "^2.9.1",
     "magic-string": "^0.30.11",
+    "oxc-parser": "^0.38.0",
     "pathe": "^1.1.2",
     "unplugin": "^1.14.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.7.1",
-    "@babel/types": "^7.25.6",
     "@nuxt/kit": "^3.13.2",
     "@nuxt/schema": "^3.13.2",
+    "@oxc-project/types": "^0.38.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.7.0",
     "@vitest/ui": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "h3": "1.12.0",
     "launch-editor": "^2.9.1",
     "magic-string": "^0.30.11",
-    "oxc-parser": "^0.38.0",
+    "oxc-parser": "^0.40.1",
     "pathe": "^1.1.2",
     "unplugin": "^1.14.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^0.30.11
         version: 0.30.11
       oxc-parser:
-        specifier: ^0.38.0
-        version: 0.38.0
+        specifier: ^0.40.1
+        version: 0.40.1
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -59,7 +59,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^3.7.1
-        version: 3.7.1(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@1.21.6))(svelte@4.2.12)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))
+        version: 3.7.1(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@2.4.1))(svelte@4.2.12)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))
       '@nuxt/kit':
         specifier: ^3.13.2
         version: 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
@@ -86,7 +86,7 @@ importers:
         version: 5.3.0
       eslint:
         specifier: ^9.11.1
-        version: 9.11.1(jiti@1.21.6)
+        version: 9.11.1(jiti@2.4.1)
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -110,10 +110,10 @@ importers:
         version: 3.0.0-rc.6(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))
       vite:
         specifier: 'catalog:'
-        version: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+        version: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       vitest:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3)
@@ -131,7 +131,7 @@ importers:
         version: 1.1.44
       '@shikijs/vitepress-twoslash':
         specifier: ^1.14.1
-        version: 1.14.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(typescript@5.6.2)
+        version: 1.14.1(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(typescript@5.6.2)
       case-police:
         specifier: ^0.6.1
         version: 0.6.1
@@ -143,7 +143,7 @@ importers:
         version: link:..
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+        version: 0.10.1(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
       vitepress:
         specifier: ^1.3.3
         version: 1.3.3(@algolia/client-search@4.24.0)(@types/node@22.7.0)(@types/react@18.3.3)(postcss@8.4.49)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(terser@5.30.3)(typescript@5.6.2)
@@ -181,7 +181,7 @@ importers:
         version: 1.2.0
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.6.2))
+        version: 5.0.5(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.6.2))
       core-js:
         specifier: ^3.37.1
         version: 3.37.1
@@ -221,10 +221,10 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+        version: 1.6.3(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
       nuxt:
         specifier: ^3.12.2
-        version: 3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3)
+        version: 3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@2.4.1))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3)
       unplugin-turbo-console:
         specifier: workspace:*
         version: link:../..
@@ -261,7 +261,7 @@ importers:
         version: 0.14.5(solid-js@1.8.22)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       solid-js:
         specifier: ^1.8.22
         version: 1.8.22
@@ -276,19 +276,19 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.2
-        version: 3.2.2(@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))
+        version: 3.2.2(@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))
       '@sveltejs/kit':
         specifier: ^2.5.17
-        version: 2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       svelte:
         specifier: ^4.2.7
         version: 4.2.12
       svelte-check:
         specifier: ^3.8.1
-        version: 3.8.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)
+        version: 3.8.1(@babel/core@7.26.0)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -300,7 +300,7 @@ importers:
         version: link:../..
       vite:
         specifier: 'catalog:'
-        version: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+        version: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
 
   examples/vite-vue3:
     dependencies:
@@ -316,7 +316,7 @@ importers:
         version: 20.14.6
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.4.5))
+        version: 5.0.5(vite@6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.4.5))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -331,10 +331,10 @@ importers:
         version: link:../..
       vite:
         specifier: 'catalog:'
-        version: 6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+        version: 6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       vue-tsc:
         specifier: ^2.0.21
         version: 2.0.21(typescript@5.4.5)
@@ -353,7 +353,7 @@ importers:
         version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.29(typescript@5.4.5))
       '@vue/cli-plugin-typescript':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@2.4.1))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))
       '@vue/cli-service':
         specifier: ~5.0.8
         version: 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
@@ -571,6 +571,10 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.23.5':
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
@@ -583,6 +587,10 @@ packages:
     resolution: {integrity: sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.26.3':
+    resolution: {integrity: sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.23.5':
     resolution: {integrity: sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==}
     engines: {node: '>=6.9.0'}
@@ -593,6 +601,10 @@ packages:
 
   '@babel/core@7.25.2':
     resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.0':
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.23.5':
@@ -613,6 +625,10 @@ packages:
 
   '@babel/generator@7.25.6':
     resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.26.3':
+    resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -641,6 +657,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.25.2':
     resolution: {integrity: sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.25.9':
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.23.5':
@@ -720,6 +740,10 @@ packages:
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.23.3':
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
@@ -734,6 +758,12 @@ packages:
 
   '@babel/helper-module-transforms@7.25.2':
     resolution: {integrity: sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -814,8 +844,16 @@ packages:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.23.5':
@@ -828,6 +866,10 @@ packages:
 
   '@babel/helper-validator-option@7.24.8':
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.22.20':
@@ -844,6 +886,10 @@ packages:
 
   '@babel/helpers@7.25.0':
     resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.26.0':
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.23.4':
@@ -870,6 +916,11 @@ packages:
 
   '@babel/parser@7.25.6':
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.26.3':
+    resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1400,6 +1451,10 @@ packages:
     resolution: {integrity: sha512-V4uqWeedadiuiCx5P5OHYJZ1PehdMpcBccNCEptKFGPiZIY3FI5f2ClxUl4r5wZ5U+ohcQ+4KW6jX2K6xXzq4Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/standalone@7.26.4':
+    resolution: {integrity: sha512-SF+g7S2mhTT1b7CHyfNjDkPU1corxg4LPYsyP0x5KuCl+EbtBQHRLqr9N3q7e7+x7NQ5LYxQf8mJ2PmzebLr0A==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.22.15':
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
@@ -1414,6 +1469,10 @@ packages:
 
   '@babel/template@7.25.0':
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.23.5':
@@ -1436,12 +1495,20 @@ packages:
     resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.26.4':
+    resolution: {integrity: sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.24.7':
     resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.3':
+    resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
   '@clack/core@0.3.4':
@@ -2949,17 +3016,17 @@ packages:
   '@nuxt/devalue@2.0.2':
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
-  '@nuxt/devtools-kit@1.6.1':
-    resolution: {integrity: sha512-6pvK5ih4XONVMSABlDbq6q7/TrZ++hyXGn5zdROVU780aYX3EjU8F0sq+1Lmc6ieiJg4tNe/EA+zV1onKRPsrQ==}
+  '@nuxt/devtools-kit@1.6.3':
+    resolution: {integrity: sha512-rcWpsGUnaDyGtmA667A4FDrVWdjuAturHV+Lkt3Xmedu5G4wC4sOzoA0+/Yco3/kWZ6fLVUTKwI2mvfzaQIugA==}
     peerDependencies:
       vite: '*'
 
-  '@nuxt/devtools-wizard@1.6.1':
-    resolution: {integrity: sha512-MpcKHgXJd4JyhJEvcIMTZqojyDFHLt9Wx2oWbV7YSEnubtHYxUM6p2M+Nb9/3mT+qoOiZQ+0db3xVcMW92oE8Q==}
+  '@nuxt/devtools-wizard@1.6.3':
+    resolution: {integrity: sha512-CvrnHTzEwfyCh06Z9I9F10MMqdhMCqpDGJaLsjzGyUoRAcFps9PRb1gyvSE/mwXBM6xsNltyUTccYwzdRCj0pA==}
     hasBin: true
 
-  '@nuxt/devtools@1.6.1':
-    resolution: {integrity: sha512-s+4msaf8/REaXVbBDzjMgdUmEwR68hpoiQWx4QkH0JHSNQXWCWgNngqlZOM3DSRmPrelS57PJCag+L7gnT1wLw==}
+  '@nuxt/devtools@1.6.3':
+    resolution: {integrity: sha512-+pwNrOrpWYMUpVDo7VtBBcYGA2QCXc+RjLP2lPpPFfXHQrStlFT2/7bi+byzwzn7ZtcMRbOMVV6Lbf7oma4HIw==}
     hasBin: true
     peerDependencies:
       vite: '*'
@@ -2972,12 +3039,20 @@ packages:
     resolution: {integrity: sha512-KvRw21zU//wdz25IeE1E5m/aFSzhJloBRAQtv+evcFeZvuroIxpIQuUqhbzuwznaUwpiWbmwlcsp5uOWmi4vwA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  '@nuxt/kit@3.14.1592':
+    resolution: {integrity: sha512-r9r8bISBBisvfcNgNL3dSIQHSBe0v5YkX5zwNblIC2T0CIEgxEVoM5rq9O5wqgb5OEydsHTtT2hL57vdv6VT2w==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   '@nuxt/schema@3.12.2':
     resolution: {integrity: sha512-IRBuOEPOIe1CANKnO2OUiqZ1Hp/0htPkLaigK7WT6ef/SdIFZUd68Tqqejqy2AFrbgU9G80k3U7eg2XUdaiQlQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   '@nuxt/schema@3.13.2':
     resolution: {integrity: sha512-CCZgpm+MkqtOMDEgF9SWgGPBXlQ01hV/6+2reDEpJuqFPGzV8HYKPBcIFvn7/z5ahtgutHLzjP71Na+hYcqSpw==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  '@nuxt/schema@3.14.1592':
+    resolution: {integrity: sha512-A1d/08ueX8stTXNkvGqnr1eEXZgvKn+vj6s7jXhZNWApUSqMgItU4VK28vrrdpKbjIPwq2SwhnGOHUYvN9HwCQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   '@nuxt/telemetry@2.5.4':
@@ -2990,48 +3065,51 @@ packages:
     peerDependencies:
       vue: ^3.3.4
 
-  '@oxc-parser/binding-darwin-arm64@0.38.0':
-    resolution: {integrity: sha512-yMDY/KrF2gEEpVIzaVWuO1savy303onvhg96a+1mUfLhgH9lvfZZyus4/LVokRHYCCy+6ey/1ytyilVnSeTDYA==}
+  '@oxc-parser/binding-darwin-arm64@0.40.1':
+    resolution: {integrity: sha512-Y8liZVQ6gT0gt2i8EhfhXzMe+wWyFUk2DQdJw3oM9DNgKB9aPINie/IJsTb1VYOudOXUXgWt3DSiFMyWJVdYeA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.38.0':
-    resolution: {integrity: sha512-OD8PQT5nAdNCbmzMVfafIQi9/yxSvfEH5fpLXPKVTCtAEc/d5aX6JpipjW231/3TF8mjXO1y3xZM1xKGXJEk/A==}
+  '@oxc-parser/binding-darwin-x64@0.40.1':
+    resolution: {integrity: sha512-m5xEhvPZDtHunP+qOFvwsX5ywtYVHwkZNilP5q5aZk9S8HwIT7WVvwkijVLqC+qqx2vYpJPjlZOJi6tHGTEwcw==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.38.0':
-    resolution: {integrity: sha512-REfFdTk+cdIC8etE8v0CoZtVObKIiymFsPkQTYca2V2ZwJ9/SgUr6NNNjLJdkGOipwjBk8d2cyOZzNDIMfzmqw==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.40.1':
+    resolution: {integrity: sha512-bIH/pYRrti1cB/y8Xc0bQgDZqOWi4UKmK6Dz3MjjUAjW+8xs+P+mVoTV8ZBl/Fi1ATgVHEFRzMM133PxvVC3uA==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.38.0':
-    resolution: {integrity: sha512-tSDRTahOoT4KDS0dicDEFgBH2nEDqNmqFG+N6PS2LrExYEDS01noRIxMFpx2Sz22a+6ZnvkfVmStp6VK+9fpBQ==}
+  '@oxc-parser/binding-linux-arm64-musl@0.40.1':
+    resolution: {integrity: sha512-PiO4p2sufi2rdm0m7bcJseQ+WGJ9clrqGXkNDy5QIIcKHRS1+9gII5nUq6knBsseACT5dp2DidgLh2wopNl0+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.38.0':
-    resolution: {integrity: sha512-qc6NdCzcCAxCK5KVde2ULq+7cyiJwrMV/1yozSUqvu26yme56Es3rWHFuPToxrhw+2olvc93AX+PVYMy3DqrGw==}
+  '@oxc-parser/binding-linux-x64-gnu@0.40.1':
+    resolution: {integrity: sha512-AvIpUxuCzRsPxHua3DYE/uMLFMG3ie1pofHduHv55gVWpjxUEoQC+1/RcMAefC2bPOE9Q4nauPXMqYMC7Oy+DA==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-musl@0.38.0':
-    resolution: {integrity: sha512-x/9XyivlMjnQ7gofNK6u+L+BMdwKf/GuLJ0vrmrWolKGR9CBSzZRwZfTw+cG0T7U6Y6CN36tSqijA0eTo3U8zw==}
+  '@oxc-parser/binding-linux-x64-musl@0.40.1':
+    resolution: {integrity: sha512-6GfUSnCxbfxT5eJl5dZTVVwEiD7amSt84jZIq81L7JTnc9n0U1FZI9WT7KfTA/rjeFvAb8DRKEBp0jHXrR0ajQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.38.0':
-    resolution: {integrity: sha512-SUlt+MUid0VUL5cLbbZzVGA9xNoqLl29xF1ueTeDt/BdQyrLELjTxoGtgisF6blAD6Rj2JqPtnfk+CT7GBwL2w==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.40.1':
+    resolution: {integrity: sha512-busM0lUeCW87eDcBTObH70h8Q1NDSCH3lsn3RRq64/wgIqSPyBYfhHu8C5CoqVOVJjd7Sb7/yQMF211Rscv0DQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.38.0':
-    resolution: {integrity: sha512-l/nFJutJ+zZTGj7ayL22r+og8g6dOC/47fSlsyl+KQXsmAFDStaARioHP9g+von/0bS23LX/9Eo8YeK5kFc7KA==}
+  '@oxc-parser/binding-win32-x64-msvc@0.40.1':
+    resolution: {integrity: sha512-uuPSt7vYjIw8p8Kdc5I+7bqPRF1WFzu6Pk3zrSM98FjV9COsyKXY6Er6qQ8nfU37TC/Hlyc3FB+qxTFzqZkuwg==}
     cpu: [x64]
     os: [win32]
 
   '@oxc-project/types@0.38.0':
     resolution: {integrity: sha512-WjRra3cmQt/VPRTwiVuYITm6RNr4SjwYeVZkT0oPn1M0Li2caILj1mlRELhHXad4nLAlnfliH5daHFKjQ9d3jQ==}
+
+  '@oxc-project/types@0.40.1':
+    resolution: {integrity: sha512-jhJXVcly+LREGeLskOt76bxPTxkF4RV7xDDGBO+H1CwK5grjMBWLlNnicI+ljSq3PkZEEU6dQrES9HMsRuk2HA==}
 
   '@parcel/watcher-android-arm64@2.4.1':
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -4648,6 +4726,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
@@ -4910,9 +4993,6 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
-  birpc@0.2.17:
-    resolution: {integrity: sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==}
-
   birpc@0.2.19:
     resolution: {integrity: sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==}
 
@@ -4964,6 +5044,11 @@ packages:
 
   browserslist@4.23.3:
     resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.24.2:
+    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -5034,6 +5119,14 @@ packages:
       magicast:
         optional: true
 
+  c12@2.0.1:
+    resolution: {integrity: sha512-Z4JgsKXHG37C6PYUtIxCfLJZvo6FyhHJoClwwb9ftUkLpPSkuYqn6Tr+vnaN8hymm0kIbcg6Ey3kv/Q71k5w/A==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -5082,6 +5175,9 @@ packages:
 
   caniuse-lite@1.0.30001651:
     resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
+
+  caniuse-lite@1.0.30001687:
+    resolution: {integrity: sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==}
 
   case-police@0.6.1:
     resolution: {integrity: sha512-tOgkG3HhtzNVHU+HVHqbpVJ3CICPDihtlgoM2C4dx0RLeo6qcNVeBgiYJN5Bln+stxKrnKrw89CFgqYQDqwZQg==}
@@ -5137,6 +5233,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -5325,6 +5425,9 @@ packages:
 
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
@@ -5578,8 +5681,8 @@ packages:
     resolution: {integrity: sha512-Hq1+lXVgjJjcS/U+uk6+yVmtxami0r0b+xVtlGyABgdz110l/kOnHWvlSI7nVzrTl8GCdZHwZS4pbBFT7hSL/g==}
     engines: {node: '>=18.0'}
 
-  cronstrue@2.50.0:
-    resolution: {integrity: sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==}
+  cronstrue@2.52.0:
+    resolution: {integrity: sha512-NKgHbWkSZXJUcaBHSsyzC8eegD6bBd4O0oCI6XMIJ+y4Bq3v4w7sY3wfWoKPuVlq9pQHRB6od0lmKpIqi8TlKA==}
     hasBin: true
 
   cross-spawn@6.0.5:
@@ -5789,6 +5892,15 @@ packages:
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -6011,6 +6123,10 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
     engines: {node: '>=4'}
@@ -6033,6 +6149,9 @@ packages:
 
   electron-to-chromium@1.5.6:
     resolution: {integrity: sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==}
+
+  electron-to-chromium@1.5.72:
+    resolution: {integrity: sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==}
 
   emmet@2.4.6:
     resolution: {integrity: sha512-dJfbdY/hfeTyf/Ef7Y7ubLYzkBvPQ912wPaeVYpAxvFxkEBf/+hJu4H6vhAvFN6HlxqedlfVn2x1S44FfQ97pg==}
@@ -6138,6 +6257,10 @@ packages:
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
@@ -6473,6 +6596,14 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -6524,6 +6655,9 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  flatted@3.3.2:
+    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -7014,6 +7148,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@6.0.2:
+    resolution: {integrity: sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==}
+    engines: {node: '>= 4'}
+
   image-meta@0.2.1:
     resolution: {integrity: sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw==}
 
@@ -7294,6 +7432,10 @@ packages:
     resolution: {integrity: sha512-pmfRbVRs/7khFrSAYnSiJ8C0D5GvzkE4Ey2pAvUcJsw1ly/p+7ut27jbJrjY79BpAJQJ4gXYFtK6d1Aub+9baQ==}
     hasBin: true
 
+  jiti@2.4.1:
+    resolution: {integrity: sha512-yPBThwecp1wS9DmoA4x4KR2h3QoslacnDR8ypuFM962kI4/456Iy1oHx2RAgh4jfZNdn0bctsdadceiBUgpU1g==}
+    hasBin: true
+
   joi@17.11.0:
     resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}
 
@@ -7306,6 +7448,9 @@ packages:
 
   js-tokens@9.0.0:
     resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -7463,6 +7608,10 @@ packages:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
     engines: {node: '>=14'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -7496,6 +7645,10 @@ packages:
 
   local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
+    engines: {node: '>=14'}
+
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
 
   locate-character@3.0.0:
@@ -7602,6 +7755,9 @@ packages:
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  magic-string@0.30.15:
+    resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
 
   magicast@0.2.11:
     resolution: {integrity: sha512-6saXbRDA1HMkqbsvHOU6HBjCVgZT460qheRkLhJQHWAbhXoWESI3Kn/dGGXyKs15FFKR85jsUqFx2sMK0wy/5g==}
@@ -8043,6 +8199,9 @@ packages:
   mlly@1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
 
+  mlly@1.7.3:
+    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
 
@@ -8188,6 +8347,9 @@ packages:
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
@@ -8254,11 +8416,6 @@ packages:
       '@types/node':
         optional: true
 
-  nypm@0.3.11:
-    resolution: {integrity: sha512-E5GqaAYSnbb6n1qZyik2wjPDZON43FqOJO59+3OkWrnmQtjggrMOVnsyzfjxp/tS6nlYJBA4zRA5jSM2YaadMg==}
-    engines: {node: ^14.16.0 || >=16.10.0}
-    hasBin: true
-
   nypm@0.3.8:
     resolution: {integrity: sha512-IGWlC6So2xv6V4cIDmoV0SwwWx7zLG086gyqkyumteH2fIgCAM4nDVFB2iDRszDvmdSVW9xb1N+2KjQ6C7d4og==}
     engines: {node: ^14.16.0 || >=16.10.0}
@@ -8266,6 +8423,11 @@ packages:
 
   nypm@0.3.9:
     resolution: {integrity: sha512-BI2SdqqTHg2d4wJh8P9A1W+bslg33vOE9IZDY6eR2QC+Pu1iNBVZUqczrd43rJb+fMzHU7ltAYKsEFY/kHMFcw==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  nypm@0.4.1:
+    resolution: {integrity: sha512-1b9mihliBh8UCcKtcGRu//G50iHpjxIQVUqkdhPT/SDVE7KdJKoHXLS0heuYTQCx95dFqiyUbXZB9r8ikn+93g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
@@ -8366,8 +8528,8 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  oxc-parser@0.38.0:
-    resolution: {integrity: sha512-w/cUL64wDb72gaBoOnvodKgHhNF9pDjb2b8gPkDKJDTvIvlbcE9XGDT3cnXOP4N3XCMrRT4MC23bCHGb3gCFSQ==}
+  oxc-parser@0.40.1:
+    resolution: {integrity: sha512-uN+yvg3rJX6SDtWq4unomdlhafjj0X82yT3DS64XGSG8+bNEBe4ktA95K/WRFH/0l7/pB2xcvo40tFfEqDx+hQ==}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -8592,6 +8754,9 @@ packages:
 
   pkg-types@1.2.0:
     resolution: {integrity: sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==}
+
+  pkg-types@1.2.1:
+    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -9175,6 +9340,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
 
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
@@ -9781,6 +9950,9 @@ packages:
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9878,6 +10050,9 @@ packages:
 
   strip-literal@2.1.0:
     resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -10116,6 +10291,13 @@ packages:
   tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
 
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+
+  tinyglobby@0.2.10:
+    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+    engines: {node: '>=12.0.0'}
+
   tinyglobby@0.2.6:
     resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
     engines: {node: '>=12.0.0'}
@@ -10316,6 +10498,9 @@ packages:
   unctx@2.3.1:
     resolution: {integrity: sha512-PhKke8ZYauiqh3FEMVNm7ljvzQiph0Mt3GBRve03IJm7ukfaON2OBK795tLwhbyfzknuRRkW0+Ze+CQUmzOZ+A==}
 
+  unctx@2.4.0:
+    resolution: {integrity: sha512-VSwGlVn3teRLkFS9OH4JoZ25ky133vVPQkS6qHv/itYVrqHBa+7SO46Yh07Zve1WEi9A1X135g9DR6KMv6ZsJg==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -10366,6 +10551,9 @@ packages:
 
   unimport@3.12.0:
     resolution: {integrity: sha512-5y8dSvNvyevsnw4TBQkIQR1Rjdbb+XjVSwQwxltpnVZrStBvvPkMPcZrh1kg5kY77kpx6+D4Ztd3W6FOBH/y2Q==}
+
+  unimport@3.14.5:
+    resolution: {integrity: sha512-tn890SwFFZxqaJSKQPPd+yygfKSATbM8BZWW1aCR2TJBTs1SDrmLamBueaFtYsGjHtQaRgqEbQflOjN2iW12gA==}
 
   unimport@3.7.2:
     resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
@@ -10452,6 +10640,14 @@ packages:
       webpack-sources:
         optional: true
 
+  unplugin@1.16.0:
+    resolution: {integrity: sha512-5liCNPuJW8dqh3+DM6uNM2EI3MLLpCKp/KY+9pB5M2S2SR2qvvDHhKgBOaTWEbZTAws3CXfB0rKTIolWKL05VQ==}
+    engines: {node: '>=14.0.0'}
+
+  unplugin@2.0.0:
+    resolution: {integrity: sha512-26eihuX14zPtiW6gzz8B112Buhi9CaWH/5ezO67pzBhKoz3MfHyc2lz/QOMOyEd/DWk+OnS0zCiYixnm8Q3dqA==}
+    engines: {node: '>=18.12.0'}
+
   unstorage@1.10.2:
     resolution: {integrity: sha512-cULBcwDqrS8UhlIysUJs2Dk0Mmt8h7B0E6mtR+relW9nZvsf/u4SkAYyNliPiPW7XtFNb5u3IUMkxGxFTTRTgQ==}
     peerDependencies:
@@ -10508,6 +10704,10 @@ packages:
     resolution: {integrity: sha512-nC5q0DnPEPVURPhfPQLahhSTnemVtPzdx7ofiRxXpOB2SYnb3MfdU3DVGyJdS8Lx+tBWeAePO8BfU/3EgksM7Q==}
     hasBin: true
 
+  untyped@1.5.1:
+    resolution: {integrity: sha512-reBOnkJBFfBZ8pCKaeHgfZLcehXtM6UTxc+vqs1JvCps0c4amLNp3fhdGBZwYp+VLyoY9n3X5KOP7lCyWBUX9A==}
+    hasBin: true
+
   unwasm@0.3.9:
     resolution: {integrity: sha512-LDxTx/2DkFURUd+BU1vUsF/moj0JsoTvl+2tcg2AUOiEzVturhGGx17/IMgGvKUYdZwr33EJHtChCJuhu9Ouvg==}
 
@@ -10519,6 +10719,12 @@ packages:
 
   update-browserslist-db@1.1.0:
     resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.1.1:
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -10652,12 +10858,12 @@ packages:
       '@nuxt/kit':
         optional: true
 
-  vite-plugin-inspect@0.8.7:
-    resolution: {integrity: sha512-/XXou3MVc13A5O9/2Nd6xczjrUwt7ZyI9h8pTnUMkr5SshLcb0PJUOVq2V+XVkdeU4njsqAtmK87THZuO2coGA==}
+  vite-plugin-inspect@0.8.9:
+    resolution: {integrity: sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A==}
     engines: {node: '>=14'}
     peerDependencies:
       '@nuxt/kit': '*'
-      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.1
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
@@ -11491,42 +11697,42 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@3.7.1(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@1.21.6))(svelte@4.2.12)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))':
+  '@antfu/eslint-config@3.7.1(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@2.4.1))(svelte@4.2.12)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
-      '@eslint-community/eslint-plugin-eslint-comments': 4.4.0(eslint@9.11.1(jiti@1.21.6))
-      '@eslint/markdown': 6.1.0(eslint@9.11.1(jiti@1.21.6))
-      '@stylistic/eslint-plugin': 2.8.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      '@typescript-eslint/eslint-plugin': 8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      '@vitest/eslint-plugin': 1.1.4(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-config-flat-gitignore: 0.3.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.4.0(eslint@9.11.1(jiti@2.4.1))
+      '@eslint/markdown': 6.1.0(eslint@9.11.1(jiti@2.4.1))
+      '@stylistic/eslint-plugin': 2.8.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      '@typescript-eslint/eslint-plugin': 8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      '@vitest/eslint-plugin': 1.1.4(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-config-flat-gitignore: 0.3.0(eslint@9.11.1(jiti@2.4.1))
       eslint-flat-config-utils: 0.4.0
-      eslint-merge-processors: 0.1.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-antfu: 2.7.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-command: 0.2.5(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-import-x: 4.3.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      eslint-plugin-jsdoc: 50.2.4(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-jsonc: 2.16.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-n: 17.10.3(eslint@9.11.1(jiti@1.21.6))
+      eslint-merge-processors: 0.1.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-antfu: 2.7.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-command: 0.2.5(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-import-x: 4.3.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      eslint-plugin-jsdoc: 50.2.4(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-jsonc: 2.16.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-n: 17.10.3(eslint@9.11.1(jiti@2.4.1))
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 3.7.0(eslint@9.11.1(jiti@1.21.6))(svelte@4.2.12)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@1.21.6)))
-      eslint-plugin-regexp: 2.6.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-toml: 0.11.1(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-unicorn: 55.0.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-vue: 9.28.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-plugin-yml: 1.14.0(eslint@9.11.1(jiti@1.21.6))
-      eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@1.21.6))
+      eslint-plugin-perfectionist: 3.7.0(eslint@9.11.1(jiti@2.4.1))(svelte@4.2.12)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@2.4.1)))
+      eslint-plugin-regexp: 2.6.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-toml: 0.11.1(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-unicorn: 55.0.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-vue: 9.28.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-plugin-yml: 1.14.0(eslint@9.11.1(jiti@2.4.1))
+      eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@2.4.1))
       globals: 15.9.0
       jsonc-eslint-parser: 2.4.0
       local-pkg: 0.5.0
       parse-gitignore: 2.0.0
       picocolors: 1.1.0
       toml-eslint-parser: 0.10.0
-      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@1.21.6))
+      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@2.4.1))
       yaml-eslint-parser: 1.2.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -11682,11 +11888,19 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.1.0
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.23.5': {}
 
   '@babel/compat-data@7.24.7': {}
 
   '@babel/compat-data@7.25.2': {}
+
+  '@babel/compat-data@7.26.3': {}
 
   '@babel/core@7.23.5':
     dependencies:
@@ -11748,6 +11962,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.26.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.3
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.3
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.23.5':
     dependencies:
       '@babel/types': 7.25.6
@@ -11782,6 +12016,14 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
+
+  '@babel/generator@7.26.3':
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
@@ -11824,6 +12066,14 @@ snapshots:
       '@babel/compat-data': 7.25.2
       '@babel/helper-validator-option': 7.24.8
       browserslist: 4.23.3
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-compilation-targets@7.25.9':
+    dependencies:
+      '@babel/compat-data': 7.26.3
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -11895,7 +12145,7 @@ snapshots:
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -11958,6 +12208,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
@@ -11985,6 +12242,15 @@ snapshots:
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12075,13 +12341,19 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.24.7': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
   '@babel/helper-validator-option@7.24.7': {}
 
   '@babel/helper-validator-option@7.24.8': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helper-wrap-function@7.22.20':
     dependencies:
@@ -12106,6 +12378,11 @@ snapshots:
     dependencies:
       '@babel/template': 7.25.0
       '@babel/types': 7.25.6
+
+  '@babel/helpers@7.26.0':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.3
 
   '@babel/highlight@7.23.4':
     dependencies:
@@ -12138,6 +12415,10 @@ snapshots:
   '@babel/parser@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@babel/parser@7.26.3':
+    dependencies:
+      '@babel/types': 7.26.3
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.5)':
     dependencies:
@@ -12817,6 +13098,8 @@ snapshots:
 
   '@babel/standalone@7.24.4': {}
 
+  '@babel/standalone@7.26.4': {}
+
   '@babel/template@7.22.15':
     dependencies:
       '@babel/code-frame': 7.24.2
@@ -12840,6 +13123,12 @@ snapshots:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.25.3
       '@babel/types': 7.25.6
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
 
   '@babel/traverse@7.23.5':
     dependencies:
@@ -12910,6 +13199,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.26.4':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.3
+      '@babel/parser': 7.26.3
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.3
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.24.7':
     dependencies:
       '@babel/helper-string-parser': 7.24.7
@@ -12921,6 +13222,11 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.26.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@clack/core@0.3.4':
     dependencies:
@@ -13493,15 +13799,15 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.4.0(eslint@9.11.1(jiti@1.21.6))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.0(eslint@9.11.1(jiti@2.4.1))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       ignore: 5.3.2
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.11.1(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.11.1(jiti@2.4.1))':
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.10.0': {}
@@ -13536,9 +13842,9 @@ snapshots:
 
   '@eslint/js@9.11.1': {}
 
-  '@eslint/markdown@6.1.0(eslint@9.11.1(jiti@1.21.6))':
+  '@eslint/markdown@6.1.0(eslint@9.11.1(jiti@2.4.1))':
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       mdast-util-from-markdown: 2.0.1
       mdast-util-gfm: 3.0.0
       micromark-extension-gfm: 3.0.0
@@ -13683,7 +13989,7 @@ snapshots:
       '@iconify/types': 2.0.0
       debug: 4.3.6
       kolorist: 1.8.0
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       mlly: 1.7.1
     transitivePeerDependencies:
       - supports-color
@@ -13866,7 +14172,7 @@ snapshots:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.6.2
       tar: 6.2.0
     transitivePeerDependencies:
       - encoding
@@ -13948,19 +14254,18 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.6.1(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)':
+  '@nuxt/devtools-kit@1.6.3(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.22.4)
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.22.4)
       execa: 7.2.0
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
 
-  '@nuxt/devtools-wizard@1.6.1':
+  '@nuxt/devtools-wizard@1.6.3':
     dependencies:
       consola: 3.2.3
       diff: 7.0.0
@@ -13968,48 +14273,48 @@ snapshots:
       global-directory: 4.0.1
       magicast: 0.3.5
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      pkg-types: 1.2.1
       prompts: 2.4.2
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
+  '@nuxt/devtools@1.6.3(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.6.1(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)
-      '@nuxt/devtools-wizard': 1.6.1
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/devtools-kit': 1.6.3(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+      '@nuxt/devtools-wizard': 1.6.3
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.22.4)
       '@vue/devtools-core': 7.6.4(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
       '@vue/devtools-kit': 7.6.4
-      birpc: 0.2.17
+      birpc: 0.2.19
       consola: 3.2.3
-      cronstrue: 2.50.0
+      cronstrue: 2.52.0
       destr: 2.0.3
       error-stack-parser-es: 0.1.5
       execa: 7.2.0
       fast-npm-meta: 0.2.2
-      flatted: 3.3.1
+      flatted: 3.3.2
       get-port-please: 3.1.2
       hookable: 5.5.3
       image-meta: 0.2.1
       is-installed-globally: 1.0.0
       launch-editor: 2.9.1
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       magicast: 0.3.5
-      nypm: 0.3.11
+      nypm: 0.4.1
       ohash: 1.1.4
       pathe: 1.1.2
       perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
+      pkg-types: 1.2.1
       rc9: 2.1.2
       scule: 1.3.0
       semver: 7.6.3
       simple-git: 3.27.0
-      sirv: 2.0.4
-      tinyglobby: 0.2.6
-      unimport: 3.12.0(rollup@4.22.4)(webpack-sources@3.2.3)
+      sirv: 3.0.0
+      tinyglobby: 0.2.10
+      unimport: 3.14.5(rollup@4.22.4)
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.22.4))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
       which: 3.0.1
       ws: 8.18.0
@@ -14019,7 +14324,6 @@ snapshots:
       - supports-color
       - utf-8-validate
       - vue
-      - webpack-sources
 
   '@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)':
     dependencies:
@@ -14077,33 +14381,59 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)':
+  '@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.22.4)':
     dependencies:
-      '@nuxt/schema': 3.13.2(rollup@4.27.4)(webpack-sources@3.2.3)
-      c12: 1.11.2(magicast@0.3.5)
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.22.4)
+      c12: 2.0.1(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
       globby: 14.0.2
       hash-sum: 2.0.0
-      ignore: 5.3.2
-      jiti: 1.21.6
+      ignore: 6.0.2
+      jiti: 2.4.1
       klona: 2.0.6
       knitwork: 1.1.0
-      mlly: 1.7.1
+      mlly: 1.7.3
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      pkg-types: 1.2.1
       scule: 1.3.0
       semver: 7.6.3
       ufo: 1.5.4
-      unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.12.0(rollup@4.27.4)(webpack-sources@3.2.3)
-      untyped: 1.4.2
+      unctx: 2.4.0
+      unimport: 3.14.5(rollup@4.22.4)
+      untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
+
+  '@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4)':
+    dependencies:
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.27.4)
+      c12: 2.0.1(magicast@0.3.5)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      hash-sum: 2.0.0
+      ignore: 6.0.2
+      jiti: 2.4.1
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      semver: 7.6.3
+      ufo: 1.5.4
+      unctx: 2.4.0
+      unimport: 3.14.5(rollup@4.27.4)
+      untyped: 1.5.1
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
     optional: true
 
   '@nuxt/schema@3.12.2(rollup@4.22.4)(webpack-sources@3.2.3)':
@@ -14144,24 +14474,45 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/schema@3.13.2(rollup@4.27.4)(webpack-sources@3.2.3)':
+  '@nuxt/schema@3.14.1592(magicast@0.3.5)(rollup@4.22.4)':
     dependencies:
+      c12: 2.0.1(magicast@0.3.5)
       compatx: 0.1.8
       consola: 3.2.3
       defu: 6.1.4
       hookable: 5.5.3
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      pkg-types: 1.2.1
       scule: 1.3.0
-      std-env: 3.7.0
+      std-env: 3.8.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.12.0(rollup@4.27.4)(webpack-sources@3.2.3)
-      untyped: 1.4.2
+      unimport: 3.14.5(rollup@4.22.4)
+      untyped: 1.5.1
     transitivePeerDependencies:
+      - magicast
       - rollup
       - supports-color
-      - webpack-sources
+
+  '@nuxt/schema@3.14.1592(magicast@0.3.5)(rollup@4.27.4)':
+    dependencies:
+      c12: 2.0.1(magicast@0.3.5)
+      compatx: 0.1.8
+      consola: 3.2.3
+      defu: 6.1.4
+      hookable: 5.5.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      std-env: 3.8.0
+      ufo: 1.5.4
+      uncrypto: 0.1.3
+      unimport: 3.14.5(rollup@4.27.4)
+      untyped: 1.5.1
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
     optional: true
 
   '@nuxt/telemetry@2.5.4(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)':
@@ -14189,7 +14540,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/vite-builder@3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
+  '@nuxt/vite-builder@3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@2.4.1))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
       '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
@@ -14223,7 +14574,7 @@ snapshots:
       unplugin: 1.14.1(webpack-sources@3.2.3)
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
       vite-node: 1.6.0(@types/node@22.7.0)(terser@5.30.3)
-      vite-plugin-checker: 0.6.4(eslint@9.11.1(jiti@1.21.6))(optionator@0.9.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))
+      vite-plugin-checker: 0.6.4(eslint@9.11.1(jiti@2.4.1))(optionator@0.9.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))
       vue: 3.5.8(typescript@5.6.2)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
@@ -14249,31 +14600,33 @@ snapshots:
       - vue-tsc
       - webpack-sources
 
-  '@oxc-parser/binding-darwin-arm64@0.38.0':
+  '@oxc-parser/binding-darwin-arm64@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.38.0':
+  '@oxc-parser/binding-darwin-x64@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.38.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.38.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.38.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.38.0':
+  '@oxc-parser/binding-linux-x64-musl@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.38.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.40.1':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.38.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.40.1':
     optional: true
 
   '@oxc-project/types@0.38.0': {}
+
+  '@oxc-project/types@0.40.1': {}
 
   '@parcel/watcher-android-arm64@2.4.1':
     optional: true
@@ -14718,10 +15071,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@shikijs/vitepress-twoslash@1.14.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(typescript@5.6.2)':
+  '@shikijs/vitepress-twoslash@1.14.1(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(typescript@5.6.2)':
     dependencies:
       '@shikijs/twoslash': 1.14.1(typescript@5.6.2)
-      floating-vue: 5.2.2(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(vue@3.4.38(typescript@5.6.2))
+      floating-vue: 5.2.2(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(vue@3.4.38(typescript@5.6.2))
       mdast-util-from-markdown: 2.0.1
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.2.0
@@ -14762,7 +15115,7 @@ snapshots:
     dependencies:
       solid-js: 1.8.22
 
-  '@solidjs/start@1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
+  '@solidjs/start@1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))
       '@vinxi/server-components': 0.4.3(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))
@@ -14777,8 +15130,8 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.1
       terracotta: 1.0.5(solid-js@1.8.22)
-      vite-plugin-inspect: 0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.22)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      vite-plugin-inspect: 0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.22)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@testing-library/jest-dom'
@@ -14788,10 +15141,10 @@ snapshots:
       - vinxi
       - vite
 
-  '@stylistic/eslint-plugin@2.8.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)':
+  '@stylistic/eslint-plugin@2.8.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      eslint: 9.11.1(jiti@1.21.6)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      eslint: 9.11.1(jiti@2.4.1)
       eslint-visitor-keys: 4.0.0
       espree: 10.1.0
       estraverse: 5.3.0
@@ -14800,14 +15153,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))':
+  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))':
     dependencies:
-      '@sveltejs/kit': 2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      '@sveltejs/kit': 2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
+  '@sveltejs/kit@2.5.17(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -14821,28 +15174,28 @@ snapshots:
       sirv: 2.0.4
       svelte: 4.2.12
       tiny-glob: 0.2.9
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       debug: 4.3.7
       svelte: 4.2.12
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)))(svelte@4.2.12)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 4.2.12
       svelte-hmr: 0.16.0(svelte@4.2.12)
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
-      vitefu: 0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vitefu: 0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15078,15 +15431,15 @@ snapshots:
     dependencies:
       '@types/node': 20.14.10
 
-  '@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 8.7.0
-      '@typescript-eslint/type-utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/type-utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.7.0
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -15096,14 +15449,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)':
+  '@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.7.0
       '@typescript-eslint/types': 8.7.0
       '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.7.0
       debug: 4.3.7
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -15114,10 +15467,10 @@ snapshots:
       '@typescript-eslint/types': 8.7.0
       '@typescript-eslint/visitor-keys': 8.7.0
 
-  '@typescript-eslint/type-utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
       debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
@@ -15143,13 +15496,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)':
+  '@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       '@typescript-eslint/scope-manager': 8.7.0
       '@typescript-eslint/types': 8.7.0
       '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15444,14 +15797,14 @@ snapshots:
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
       vue: 3.5.8(typescript@5.6.2)
 
-  '@vitejs/plugin-vue@5.0.5(vite@6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.0.5(vite@6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.4.5))':
     dependencies:
-      vite: 6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
       vue: 3.4.29(typescript@5.4.5)
 
-  '@vitejs/plugin-vue@5.0.5(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.6.2))':
+  '@vitejs/plugin-vue@5.0.5(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))(vue@3.4.29(typescript@5.6.2))':
     dependencies:
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
       vue: 3.4.29(typescript@5.6.2)
 
   '@vitejs/plugin-vue@5.1.2(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.4.38(typescript@5.6.2))':
@@ -15459,11 +15812,11 @@ snapshots:
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
       vue: 3.4.38(typescript@5.6.2)
 
-  '@vitest/eslint-plugin@1.1.4(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))':
+  '@vitest/eslint-plugin@1.1.4(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))':
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
     optionalDependencies:
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
       typescript: 5.6.2
       vitest: 2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3)
 
@@ -15809,14 +16162,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))':
+  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@2.4.1))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.23.5
       '@types/webpack-env': 1.18.4
       '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.94.0)
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.11.1(jiti@2.4.1))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0)
       globby: 11.1.0
       thread-loader: 3.0.4(webpack@5.94.0)
       ts-loader: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
@@ -16210,7 +16563,7 @@ snapshots:
   '@vue/devtools-kit@7.3.8':
     dependencies:
       '@vue/devtools-shared': 7.3.8
-      birpc: 0.2.17
+      birpc: 0.2.19
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
@@ -16250,10 +16603,10 @@ snapshots:
   '@vue/language-core@2.0.21(typescript@5.6.2)':
     dependencies:
       '@volar/language-core': 2.3.0
-      '@vue/compiler-dom': 3.5.8
-      '@vue/shared': 3.5.8
+      '@vue/compiler-dom': 3.4.21
+      '@vue/shared': 3.4.21
       computeds: 0.0.1
-      minimatch: 9.0.5
+      minimatch: 9.0.4
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.15
     optionalDependencies:
@@ -16506,11 +16859,13 @@ snapshots:
 
   acorn@8.12.1: {}
 
+  acorn@8.14.0: {}
+
   address@1.2.2: {}
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16945,8 +17300,6 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  birpc@0.2.17: {}
-
   birpc@0.2.19: {}
 
   bl@4.1.0:
@@ -17048,6 +17401,13 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
+  browserslist@4.24.2:
+    dependencies:
+      caniuse-lite: 1.0.30001687
+      electron-to-chromium: 1.5.72
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.1(browserslist@4.24.2)
+
   buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
@@ -17135,6 +17495,23 @@ snapshots:
     optionalDependencies:
       magicast: 0.3.5
 
+  c12@2.0.1(magicast@0.3.5):
+    dependencies:
+      chokidar: 4.0.1
+      confbox: 0.1.8
+      defu: 6.1.4
+      dotenv: 16.4.7
+      giget: 1.2.3
+      jiti: 2.4.1
+      mlly: 1.7.3
+      ohash: 1.1.4
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.1
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
+
   cac@6.7.14: {}
 
   cache-content-type@1.0.1:
@@ -17183,6 +17560,8 @@ snapshots:
   caniuse-lite@1.0.30001636: {}
 
   caniuse-lite@1.0.30001651: {}
+
+  caniuse-lite@1.0.30001687: {}
 
   case-police@0.6.1: {}
 
@@ -17249,6 +17628,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
 
   chownr@1.1.4:
     optional: true
@@ -17348,7 +17731,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.6
-      acorn: 8.12.1
+      acorn: 8.14.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
 
@@ -17429,6 +17812,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.7: {}
+
+  confbox@0.1.8: {}
 
   connect-history-api-fallback@2.0.0: {}
 
@@ -17516,7 +17901,7 @@ snapshots:
 
   croner@8.0.1: {}
 
-  cronstrue@2.50.0: {}
+  cronstrue@2.52.0: {}
 
   cross-spawn@6.0.5:
     dependencies:
@@ -17828,6 +18213,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
@@ -18017,6 +18406,8 @@ snapshots:
 
   dotenv@16.4.5: {}
 
+  dotenv@16.4.7: {}
+
   dset@3.1.3: {}
 
   duplexer@0.1.2: {}
@@ -18030,6 +18421,8 @@ snapshots:
   electron-to-chromium@1.4.708: {}
 
   electron-to-chromium@1.5.6: {}
+
+  electron-to-chromium@1.5.72: {}
 
   emmet@2.4.6:
     dependencies:
@@ -18276,6 +18669,8 @@ snapshots:
 
   escalade@3.1.2: {}
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
@@ -18284,19 +18679,19 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.1.2(eslint@9.11.1(jiti@1.21.6)):
+  eslint-compat-utils@0.1.2(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
 
-  eslint-compat-utils@0.5.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-compat-utils@0.5.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       semver: 7.6.3
 
-  eslint-config-flat-gitignore@0.3.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-config-flat-gitignore@0.3.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@eslint/compat': 1.1.1
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       find-up-simple: 1.0.0
 
   eslint-flat-config-utils@0.4.0:
@@ -18311,33 +18706,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-merge-processors@0.1.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-merge-processors@0.1.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
 
-  eslint-plugin-antfu@2.7.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-antfu@2.7.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@antfu/utils': 0.7.10
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
 
-  eslint-plugin-command@0.2.5(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-command@0.2.5(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.48.0
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
 
-  eslint-plugin-es-x@7.5.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-es-x@7.5.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       '@eslint-community/regexpp': 4.10.0
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-compat-utils: 0.1.2(eslint@9.11.1(jiti@1.21.6))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-compat-utils: 0.1.2(eslint@9.11.1(jiti@2.4.1))
 
-  eslint-plugin-import-x@4.3.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2):
+  eslint-plugin-import-x@4.3.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2):
     dependencies:
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
       debug: 4.3.7
       doctrine: 3.0.0
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       eslint-import-resolver-node: 0.3.9
       get-tsconfig: 4.7.5
       is-glob: 4.0.3
@@ -18349,14 +18744,14 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jsdoc@50.2.4(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-jsdoc@50.2.4(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.48.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.3.7
       escape-string-regexp: 4.0.0
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       espree: 10.1.0
       esquery: 1.6.0
       parse-imports: 2.1.1
@@ -18366,23 +18761,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.16.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-jsonc@2.16.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@2.4.1))
       espree: 9.6.1
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.0
       natural-compare: 1.4.0
       synckit: 0.6.2
 
-  eslint-plugin-n@17.10.3(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-n@17.10.3(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       enhanced-resolve: 5.17.0
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-plugin-es-x: 7.5.0(eslint@9.11.1(jiti@1.21.6))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-plugin-es-x: 7.5.0(eslint@9.11.1(jiti@2.4.1))
       get-tsconfig: 4.7.5
       globals: 15.9.0
       ignore: 5.3.2
@@ -18391,49 +18786,49 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@3.7.0(eslint@9.11.1(jiti@1.21.6))(svelte@4.2.12)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@1.21.6))):
+  eslint-plugin-perfectionist@3.7.0(eslint@9.11.1(jiti@2.4.1))(svelte@4.2.12)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@2.4.1))):
     dependencies:
       '@typescript-eslint/types': 8.7.0
-      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
-      eslint: 9.11.1(jiti@1.21.6)
+      '@typescript-eslint/utils': 8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
+      eslint: 9.11.1(jiti@2.4.1)
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
     optionalDependencies:
       svelte: 4.2.12
-      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@1.21.6))
+      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@2.4.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-regexp@2.6.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-regexp@2.6.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       '@eslint-community/regexpp': 4.10.0
       comment-parser: 1.4.1
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       jsdoc-type-pratt-parser: 4.0.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@0.11.1(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-toml@0.11.1(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       debug: 4.3.7
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@1.21.6))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@2.4.1))
       lodash: 4.17.21
       toml-eslint-parser: 0.10.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@55.0.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-unicorn@55.0.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       ci-info: 4.0.0
       clean-regexp: 1.0.0
       core-js-compat: 3.37.1
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       esquery: 1.5.0
       globals: 15.9.0
       indent-string: 4.0.0
@@ -18446,41 +18841,41 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2)
+      '@typescript-eslint/eslint-plugin': 8.7.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2))(eslint@9.11.1(jiti@2.4.1))(typescript@5.6.2)
 
-  eslint-plugin-vue@9.28.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-vue@9.28.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
-      eslint: 9.11.1(jiti@1.21.6)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
+      eslint: 9.11.1(jiti@2.4.1)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.1
       semver: 7.6.3
-      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@1.21.6))
+      vue-eslint-parser: 9.4.3(eslint@9.11.1(jiti@2.4.1))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-yml@1.14.0(eslint@9.11.1(jiti@1.21.6)):
+  eslint-plugin-yml@1.14.0(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       debug: 4.3.7
-      eslint: 9.11.1(jiti@1.21.6)
-      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@1.21.6))
+      eslint: 9.11.1(jiti@2.4.1)
+      eslint-compat-utils: 0.5.0(eslint@9.11.1(jiti@2.4.1))
       lodash: 4.17.21
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.2.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-processor-vue-blocks@0.1.2(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@1.21.6)):
+  eslint-processor-vue-blocks@0.1.2(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       '@vue/compiler-sfc': 3.5.8
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -18501,9 +18896,9 @@ snapshots:
 
   eslint-visitor-keys@4.0.0: {}
 
-  eslint@9.11.1(jiti@1.21.6):
+  eslint@9.11.1(jiti@2.4.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.1(jiti@2.4.1))
       '@eslint-community/regexpp': 4.11.1
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.6.0
@@ -18541,7 +18936,7 @@ snapshots:
       strip-ansi: 6.0.1
       text-table: 0.2.0
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18782,6 +19177,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fflate@0.8.2: {}
 
   figures@2.0.0:
@@ -18842,15 +19241,17 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  flatted@3.3.2: {}
+
   flattie@1.1.1: {}
 
-  floating-vue@5.2.2(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(vue@3.4.38(typescript@5.6.2)):
+  floating-vue@5.2.2(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(vue@3.4.38(typescript@5.6.2)):
     dependencies:
       '@floating-ui/dom': 1.1.1
       vue: 3.4.38(typescript@5.6.2)
       vue-resize: 2.0.0-alpha.1(vue@3.4.38(typescript@5.6.2))
     optionalDependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.27.4)
 
   focus-trap@7.5.4:
     dependencies:
@@ -18865,7 +19266,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.11.1(jiti@2.4.1))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.23.5
       '@types/json-schema': 7.0.15
@@ -18883,7 +19284,7 @@ snapshots:
       typescript: 5.4.5
       webpack: 5.94.0
     optionalDependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       vue-template-compiler: 2.7.15
 
   forwarded@0.2.0: {}
@@ -19452,7 +19853,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19483,6 +19884,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@6.0.2: {}
+
   image-meta@0.2.1: {}
 
   import-fresh@3.3.0:
@@ -19499,12 +19902,12 @@ snapshots:
   importx@0.4.3:
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.23.1
       jiti: 2.0.0-beta.2
       jiti-v1: jiti@1.21.6
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      pkg-types: 1.2.1
       tsx: 4.19.1
     transitivePeerDependencies:
       - supports-color
@@ -19726,6 +20129,8 @@ snapshots:
 
   jiti@2.0.0-beta.3: {}
 
+  jiti@2.4.1: {}
+
   joi@17.11.0:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -19739,6 +20144,8 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -19906,6 +20313,9 @@ snapshots:
 
   lilconfig@3.1.2: {}
 
+  lilconfig@3.1.3:
+    optional: true
+
   lines-and-columns@1.2.4: {}
 
   listhen@1.7.2:
@@ -19960,6 +20370,11 @@ snapshots:
     dependencies:
       mlly: 1.7.1
       pkg-types: 1.2.0
+
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.7.3
+      pkg-types: 1.2.1
 
   locate-character@3.0.0: {}
 
@@ -20059,6 +20474,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.15:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magicast@0.2.11:
     dependencies:
       '@babel/parser': 7.25.6
@@ -20067,8 +20486,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
       source-map-js: 1.2.1
 
   make-dir@3.1.0:
@@ -20852,6 +21271,13 @@ snapshots:
       pkg-types: 1.2.0
       ufo: 1.5.4
 
+  mlly@1.7.3:
+    dependencies:
+      acorn: 8.14.0
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      ufo: 1.5.4
+
   module-alias@2.2.3: {}
 
   mri@1.2.0: {}
@@ -21059,6 +21485,8 @@ snapshots:
 
   node-releases@2.0.18: {}
 
+  node-releases@2.0.19: {}
+
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
@@ -21115,14 +21543,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3):
+  nuxt@3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@2.4.1))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+      '@nuxt/devtools': 1.6.3(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
       '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.12.2(rollup@4.22.4)(webpack-sources@3.2.3)
       '@nuxt/telemetry': 2.5.4(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
-      '@nuxt/vite-builder': 3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+      '@nuxt/vite-builder': 3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@2.4.1))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
       '@unhead/dom': 1.9.14
       '@unhead/ssr': 1.9.14
       '@unhead/vue': 1.9.14(vue@3.5.8(typescript@5.6.2))
@@ -21220,15 +21648,6 @@ snapshots:
       - webpack-sources
       - xml2js
 
-  nypm@0.3.11:
-    dependencies:
-      citty: 0.1.6
-      consola: 3.2.3
-      execa: 8.0.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      ufo: 1.5.4
-
   nypm@0.3.8:
     dependencies:
       citty: 0.1.6
@@ -21244,6 +21663,15 @@ snapshots:
       execa: 8.0.1
       pathe: 1.1.2
       pkg-types: 1.2.0
+      ufo: 1.5.4
+
+  nypm@0.4.1:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.2.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      tinyexec: 0.3.1
       ufo: 1.5.4
 
   object-assign@4.1.1: {}
@@ -21375,18 +21803,18 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  oxc-parser@0.38.0:
+  oxc-parser@0.40.1:
     dependencies:
-      '@oxc-project/types': 0.38.0
+      '@oxc-project/types': 0.40.1
     optionalDependencies:
-      '@oxc-parser/binding-darwin-arm64': 0.38.0
-      '@oxc-parser/binding-darwin-x64': 0.38.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.38.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.38.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.38.0
-      '@oxc-parser/binding-linux-x64-musl': 0.38.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.38.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.38.0
+      '@oxc-parser/binding-darwin-arm64': 0.40.1
+      '@oxc-parser/binding-darwin-x64': 0.40.1
+      '@oxc-parser/binding-linux-arm64-gnu': 0.40.1
+      '@oxc-parser/binding-linux-arm64-musl': 0.40.1
+      '@oxc-parser/binding-linux-x64-gnu': 0.40.1
+      '@oxc-parser/binding-linux-x64-musl': 0.40.1
+      '@oxc-parser/binding-win32-arm64-msvc': 0.40.1
+      '@oxc-parser/binding-win32-x64-msvc': 0.40.1
 
   p-finally@1.0.0: {}
 
@@ -21595,6 +22023,12 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
+  pkg-types@1.2.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.3
+      pathe: 1.1.2
+
   pluralize@8.0.0: {}
 
   portfinder@1.0.32:
@@ -21753,7 +22187,7 @@ snapshots:
 
   postcss-load-config@4.0.2(postcss@8.4.49):
     dependencies:
-      lilconfig: 3.1.2
+      lilconfig: 3.1.3
       yaml: 2.5.1
     optionalDependencies:
       postcss: 8.4.49
@@ -22291,7 +22725,7 @@ snapshots:
   postcss@8.4.45:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.4.47:
@@ -22496,6 +22930,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   recast@0.23.9:
     dependencies:
@@ -23294,6 +23730,8 @@ snapshots:
 
   std-env@3.7.0: {}
 
+  std-env@3.8.0: {}
+
   stdin-discarder@0.1.0:
     dependencies:
       bl: 5.1.0
@@ -23392,6 +23830,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.0
 
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -23441,7 +23883,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12):
+  svelte-check@3.8.1(@babel/core@7.26.0)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -23450,7 +23892,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.12
-      svelte-preprocess: 5.1.3(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)(typescript@5.4.5)
+      svelte-preprocess: 5.1.3(@babel/core@7.26.0)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -23467,7 +23909,7 @@ snapshots:
     dependencies:
       svelte: 4.2.12
 
-  svelte-preprocess@5.1.3(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)(typescript@5.4.5):
+  svelte-preprocess@5.1.3(@babel/core@7.26.0)(postcss-load-config@4.0.2(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.12)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.8
       detect-indent: 6.1.0
@@ -23476,7 +23918,7 @@ snapshots:
       strip-indent: 3.0.0
       svelte: 4.2.12
     optionalDependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.26.0
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)
       typescript: 5.4.5
@@ -23487,7 +23929,7 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
       '@types/estree': 1.0.6
-      acorn: 8.12.1
+      acorn: 8.14.0
       aria-query: 5.3.0
       axobject-query: 4.0.0
       code-red: 1.0.4
@@ -23495,7 +23937,7 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.11
+      magic-string: 0.30.15
       periscopic: 3.1.0
 
   svg-tags@1.0.0: {}
@@ -23507,7 +23949,7 @@ snapshots:
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       stable: 0.1.8
 
   svgo@3.3.2:
@@ -23518,7 +23960,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   synckit@0.6.2:
     dependencies:
@@ -23602,7 +24044,7 @@ snapshots:
   terser@5.24.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
-      acorn: 8.12.1
+      acorn: 8.11.3
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -23646,6 +24088,13 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.0: {}
+
+  tinyexec@0.3.1: {}
+
+  tinyglobby@0.2.10:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinyglobby@0.2.6:
     dependencies:
@@ -23770,7 +24219,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.2:
     dependencies:
-      semver: 7.6.3
+      semver: 7.6.0
 
   typescript@5.4.5: {}
 
@@ -23835,6 +24284,13 @@ snapshots:
       unplugin: 1.14.1(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - webpack-sources
+
+  unctx@2.4.0:
+    dependencies:
+      acorn: 8.14.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.15
+      unplugin: 2.0.0
 
   undici-types@5.26.5: {}
 
@@ -23901,7 +24357,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       fast-glob: 3.3.2
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       magic-string: 0.30.11
       mlly: 1.7.1
       pathe: 1.1.2
@@ -23932,24 +24388,43 @@ snapshots:
       - rollup
       - webpack-sources
 
-  unimport@3.12.0(rollup@4.27.4)(webpack-sources@3.2.3):
+  unimport@3.14.5(rollup@4.22.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
-      acorn: 8.12.1
+      '@rollup/pluginutils': 5.1.3(rollup@4.22.4)
+      acorn: 8.14.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.15
+      mlly: 1.7.3
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      picomatch: 4.0.2
+      pkg-types: 1.2.1
       scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
+      strip-literal: 2.1.1
+      unplugin: 1.16.0
     transitivePeerDependencies:
       - rollup
-      - webpack-sources
+
+  unimport@3.14.5(rollup@4.27.4):
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      acorn: 8.14.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.2
+      local-pkg: 0.5.1
+      magic-string: 0.30.15
+      mlly: 1.7.3
+      pathe: 1.1.2
+      picomatch: 4.0.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      strip-literal: 2.1.1
+      unplugin: 1.16.0
+    transitivePeerDependencies:
+      - rollup
     optional: true
 
   unimport@3.7.2(rollup@4.22.4)(webpack-sources@3.2.3):
@@ -24100,6 +24575,16 @@ snapshots:
     optionalDependencies:
       webpack-sources: 3.2.3
 
+  unplugin@1.16.0:
+    dependencies:
+      acorn: 8.14.0
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.0.0:
+    dependencies:
+      acorn: 8.14.0
+      webpack-virtual-modules: 0.6.2
+
   unstorage@1.10.2(ioredis@5.3.2):
     dependencies:
       anymatch: 3.1.3
@@ -24137,13 +24622,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  untyped@1.5.1:
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/standalone': 7.26.4
+      '@babel/types': 7.26.3
+      defu: 6.1.4
+      jiti: 2.4.1
+      mri: 1.2.0
+      scule: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   unwasm@0.3.9(webpack-sources@3.2.3):
     dependencies:
       knitwork: 1.1.0
       magic-string: 0.30.11
       mlly: 1.7.1
       pathe: 1.1.2
-      pkg-types: 1.2.0
+      pkg-types: 1.1.1
       unplugin: 1.14.1(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - webpack-sources
@@ -24159,6 +24656,12 @@ snapshots:
       browserslist: 4.23.3
       escalade: 3.1.2
       picocolors: 1.1.0
+
+  update-browserslist-db@1.1.1(browserslist@4.24.2):
+    dependencies:
+      browserslist: 4.24.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uqr@0.1.2: {}
 
@@ -24339,7 +24842,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.4(eslint@9.11.1(jiti@1.21.6))(optionator@0.9.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2)):
+  vite-plugin-checker@0.6.4(eslint@9.11.1(jiti@2.4.1))(optionator@0.9.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2)):
     dependencies:
       '@babel/code-frame': 7.24.2
       ansi-escapes: 4.3.2
@@ -24358,7 +24861,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       optionator: 0.9.3
       typescript: 5.6.2
       vue-tsc: 2.0.21(typescript@5.6.2)
@@ -24381,7 +24884,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.3(rollup@4.22.4)
@@ -24392,14 +24895,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
@@ -24410,14 +24913,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
+  vite-plugin-inspect@0.10.1(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.4))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
@@ -24430,12 +24933,12 @@ snapshots:
       sirv: 3.0.0
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
     optionalDependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.27.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vite-plugin-inspect@0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
@@ -24445,32 +24948,32 @@ snapshots:
       open: 9.1.0
       picocolors: 1.1.0
       sirv: 2.0.4
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.22.4))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
-      debug: 4.3.7
+      '@rollup/pluginutils': 5.1.3(rollup@4.22.4)
+      debug: 4.4.0
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
       open: 10.1.0
       perfect-debounce: 1.0.0
-      picocolors: 1.1.0
-      sirv: 2.0.4
+      picocolors: 1.1.1
+      sirv: 3.0.0
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
     optionalDependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-solid@2.10.2(solid-js@1.8.22)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vite-plugin-solid@2.10.2(solid-js@1.8.22)(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@babel/core': 7.25.2
       '@types/babel__core': 7.20.5
@@ -24478,8 +24981,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.22
       solid-refresh: 0.6.3(solid-js@1.8.22)
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
-      vitefu: 0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vitefu: 0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -24518,7 +25021,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.30.3
 
-  vite@6.0.1(@types/node@20.14.6)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1):
+  vite@6.0.1(@types/node@20.14.6)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -24526,12 +25029,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.6
       fsevents: 2.3.3
-      jiti: 1.21.6
+      jiti: 2.4.1
       terser: 5.30.3
       tsx: 4.19.1
       yaml: 2.5.1
 
-  vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1):
+  vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -24539,7 +25042,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.7.0
       fsevents: 2.3.3
-      jiti: 1.21.6
+      jiti: 2.4.1
       terser: 5.30.3
       tsx: 4.19.1
       yaml: 2.5.1
@@ -24552,9 +25055,9 @@ snapshots:
     optionalDependencies:
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
 
-  vitefu@0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vitefu@0.2.5(vite@6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     optionalDependencies:
-      vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
+      vite: 6.0.1(@types/node@22.7.0)(jiti@2.4.1)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
 
   vitepress-plugin-group-icons@1.2.0:
     dependencies:
@@ -24755,10 +25258,10 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@1.21.6)):
+  vue-eslint-parser@9.4.3(eslint@9.11.1(jiti@2.4.1)):
     dependencies:
       debug: 4.3.7
-      eslint: 9.11.1(jiti@1.21.6)
+      eslint: 9.11.1(jiti@2.4.1)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -24889,7 +25392,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 2.3.0
       '@vue/language-core': 2.0.21(typescript@5.6.2)
-      semver: 7.6.3
+      semver: 7.6.0
       typescript: 5.6.2
     optional: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,15 +26,15 @@ importers:
       '@rollup/pluginutils':
         specifier: ^5.1.2
         version: 5.1.2(rollup@4.22.4)
-      ast-kit:
-        specifier: ^1.2.0
-        version: 1.2.0
       astro:
         specifier: '>=3'
         version: 3.6.4(@types/node@22.7.0)(terser@5.30.3)(typescript@5.6.2)
       esbuild:
         specifier: '*'
         version: 0.21.5
+      estree-walker:
+        specifier: ^3.0.3
+        version: 3.0.3
       get-port-please:
         specifier: ^3.1.2
         version: 3.1.2
@@ -47,6 +47,9 @@ importers:
       magic-string:
         specifier: ^0.30.11
         version: 0.30.11
+      oxc-parser:
+        specifier: ^0.38.0
+        version: 0.38.0
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -57,15 +60,15 @@ importers:
       '@antfu/eslint-config':
         specifier: ^3.7.1
         version: 3.7.1(@typescript-eslint/utils@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.5.8)(eslint@9.11.1(jiti@1.21.6))(svelte@4.2.12)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.7.0)(@vitest/ui@2.1.1)(terser@5.30.3))
-      '@babel/types':
-        specifier: ^7.25.6
-        version: 7.25.6
       '@nuxt/kit':
         specifier: ^3.13.2
         version: 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
       '@nuxt/schema':
         specifier: ^3.13.2
         version: 3.13.2(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@oxc-project/types':
+        specifier: ^0.38.0
+        version: 0.38.0
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -119,7 +122,7 @@ importers:
         version: 3.5.8(typescript@5.6.2)
       webpack:
         specifier: ^5.94.0
-        version: 5.94.0(esbuild@0.21.5)
+        version: 5.94.0
 
   docs:
     devDependencies:
@@ -190,7 +193,7 @@ importers:
     dependencies:
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -218,16 +221,16 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 1.4.2(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+        version: 1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
       nuxt:
         specifier: ^3.12.2
-        version: 3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.27.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3)
+        version: 3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3)
       unplugin-turbo-console:
         specifier: workspace:*
         version: link:../..
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+        version: 0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
 
   examples/rspack:
     dependencies:
@@ -237,7 +240,7 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 0.7.4
-        version: 0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0(esbuild@0.21.5))
+        version: 0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0)
       '@rspack/core':
         specifier: 0.7.4
         version: 0.7.4(@swc/helpers@0.5.5)
@@ -246,7 +249,7 @@ importers:
         version: link:../..
       vue-loader:
         specifier: ^17.4.2
-        version: 17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.6.2))(webpack@5.94.0(esbuild@0.21.5))
+        version: 17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.6.2))(webpack@5.94.0)
 
   examples/solid-start:
     dependencies:
@@ -258,7 +261,7 @@ importers:
         version: 0.14.5(solid-js@1.8.22)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+        version: 1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       solid-js:
         specifier: ^1.8.22
         version: 1.8.22
@@ -347,13 +350,13 @@ importers:
     devDependencies:
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(esbuild@0.21.5)(vue@3.4.29(typescript@5.4.5))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.29(typescript@5.4.5))
       '@vue/cli-plugin-typescript':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(esbuild@0.21.5)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -652,12 +655,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-create-class-features-plugin@7.25.0':
-    resolution: {integrity: sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-create-class-features-plugin@7.25.4':
     resolution: {integrity: sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==}
     engines: {node: '>=6.9.0'}
@@ -795,10 +792,6 @@ packages:
 
   '@babel/helper-simple-access@7.24.7':
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
-    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
@@ -963,12 +956,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.23.3':
     resolution: {integrity: sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.23.3':
-    resolution: {integrity: sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2962,17 +2949,17 @@ packages:
   '@nuxt/devalue@2.0.2':
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
-  '@nuxt/devtools-kit@1.4.2':
-    resolution: {integrity: sha512-8a5PhVnC7E94318/sHbNSe9mI2MlsQ8+pJLGs2Hh1OJyidB9SWe6hoFc8q4K9VOtXak9uCFVb5V2JGXS1q+1aA==}
+  '@nuxt/devtools-kit@1.6.1':
+    resolution: {integrity: sha512-6pvK5ih4XONVMSABlDbq6q7/TrZ++hyXGn5zdROVU780aYX3EjU8F0sq+1Lmc6ieiJg4tNe/EA+zV1onKRPsrQ==}
     peerDependencies:
       vite: '*'
 
-  '@nuxt/devtools-wizard@1.4.2':
-    resolution: {integrity: sha512-TyhmPBg/xJKPOdnwR3DAh8KMUt6/0dUNABCxGVeY7PYbIiXt4msIGVJkBc4y+WwIJHOYPrSRClmZVsXQfRlB4A==}
+  '@nuxt/devtools-wizard@1.6.1':
+    resolution: {integrity: sha512-MpcKHgXJd4JyhJEvcIMTZqojyDFHLt9Wx2oWbV7YSEnubtHYxUM6p2M+Nb9/3mT+qoOiZQ+0db3xVcMW92oE8Q==}
     hasBin: true
 
-  '@nuxt/devtools@1.4.2':
-    resolution: {integrity: sha512-Ok3g2P7iwKyK8LiwozbYVAZTo8t91iXSmlJj2ozeo1okKQ2Qi1AtwB6nYgIlkUHZmo155ZjG/LCHYI5uhQ/sGw==}
+  '@nuxt/devtools@1.6.1':
+    resolution: {integrity: sha512-s+4msaf8/REaXVbBDzjMgdUmEwR68hpoiQWx4QkH0JHSNQXWCWgNngqlZOM3DSRmPrelS57PJCag+L7gnT1wLw==}
     hasBin: true
     peerDependencies:
       vite: '*'
@@ -3002,6 +2989,49 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
       vue: ^3.3.4
+
+  '@oxc-parser/binding-darwin-arm64@0.38.0':
+    resolution: {integrity: sha512-yMDY/KrF2gEEpVIzaVWuO1savy303onvhg96a+1mUfLhgH9lvfZZyus4/LVokRHYCCy+6ey/1ytyilVnSeTDYA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.38.0':
+    resolution: {integrity: sha512-OD8PQT5nAdNCbmzMVfafIQi9/yxSvfEH5fpLXPKVTCtAEc/d5aX6JpipjW231/3TF8mjXO1y3xZM1xKGXJEk/A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.38.0':
+    resolution: {integrity: sha512-REfFdTk+cdIC8etE8v0CoZtVObKIiymFsPkQTYca2V2ZwJ9/SgUr6NNNjLJdkGOipwjBk8d2cyOZzNDIMfzmqw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.38.0':
+    resolution: {integrity: sha512-tSDRTahOoT4KDS0dicDEFgBH2nEDqNmqFG+N6PS2LrExYEDS01noRIxMFpx2Sz22a+6ZnvkfVmStp6VK+9fpBQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.38.0':
+    resolution: {integrity: sha512-qc6NdCzcCAxCK5KVde2ULq+7cyiJwrMV/1yozSUqvu26yme56Es3rWHFuPToxrhw+2olvc93AX+PVYMy3DqrGw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.38.0':
+    resolution: {integrity: sha512-x/9XyivlMjnQ7gofNK6u+L+BMdwKf/GuLJ0vrmrWolKGR9CBSzZRwZfTw+cG0T7U6Y6CN36tSqijA0eTo3U8zw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.38.0':
+    resolution: {integrity: sha512-SUlt+MUid0VUL5cLbbZzVGA9xNoqLl29xF1ueTeDt/BdQyrLELjTxoGtgisF6blAD6Rj2JqPtnfk+CT7GBwL2w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.38.0':
+    resolution: {integrity: sha512-l/nFJutJ+zZTGj7ayL22r+og8g6dOC/47fSlsyl+KQXsmAFDStaARioHP9g+von/0bS23LX/9Eo8YeK5kFc7KA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.38.0':
+    resolution: {integrity: sha512-WjRra3cmQt/VPRTwiVuYITm6RNr4SjwYeVZkT0oPn1M0Li2caILj1mlRELhHXad4nLAlnfliH5daHFKjQ9d3jQ==}
 
   '@parcel/watcher-android-arm64@2.4.1':
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -4367,22 +4397,22 @@ packages:
   '@vue/devtools-api@7.3.8':
     resolution: {integrity: sha512-NURFwmxz4WukFU54IHgyGI2KSejdgHG5JC4xTcWmTWEBIc8aelj9fBy4qsboObGHFp3JIdRxxANO9s2wZA/pVQ==}
 
-  '@vue/devtools-core@7.4.4':
-    resolution: {integrity: sha512-DLxgA3DfeADkRzhAfm3G2Rw/cWxub64SdP5b+s5dwL30+whOGj+QNhmyFpwZ8ZTrHDFRIPj0RqNzJ8IRR1pz7w==}
+  '@vue/devtools-core@7.6.4':
+    resolution: {integrity: sha512-blSwGVYpb7b5TALMjjoBiAl5imuBF7WEOAtaJaBMNikR8SQkm6mkUt4YlIKh9874/qoimwmpDOm+GHBZ4Y5m+g==}
     peerDependencies:
       vue: ^3.0.0
 
   '@vue/devtools-kit@7.3.8':
     resolution: {integrity: sha512-HYy3MQP1nZ6GbE4vrgJ/UB+MvZnhYmEwCa/UafrEpdpwa+jNCkz1ZdUrC5I7LpkH1ShREEV2/pZlAQdBj+ncLQ==}
 
-  '@vue/devtools-kit@7.4.4':
-    resolution: {integrity: sha512-awK/4NfsUG0nQ7qnTM37m7ZkEUMREyPh8taFCX+uQYps/MTFEum0AD05VeGDRMXwWvMmGIcWX9xp8ZiBddY0jw==}
+  '@vue/devtools-kit@7.6.4':
+    resolution: {integrity: sha512-Zs86qIXXM9icU0PiGY09PQCle4TI750IPLmAJzW5Kf9n9t5HzSYf6Rz6fyzSwmfMPiR51SUKJh9sXVZu78h2QA==}
 
   '@vue/devtools-shared@7.3.8':
     resolution: {integrity: sha512-1NiJbn7Yp47nPDWhFZyEKpB2+5/+7JYv8IQnU0ccMrgslPR2dL7u1DIyI7mLqy4HN1ll36gQy0k8GqBYSFgZJw==}
 
-  '@vue/devtools-shared@7.4.5':
-    resolution: {integrity: sha512-2XgUOkL/7QDmyYI9J7cm+rz/qBhcGv+W5+i1fhwdQ0HQ1RowhdK66F0QBuJSz/5k12opJY8eN6m03/XZMs7imQ==}
+  '@vue/devtools-shared@7.6.7':
+    resolution: {integrity: sha512-QggO6SviAsolrePAXZ/sA1dSicSPt4TueZibCvydfhNDieL1lAuyMTgQDGst7TEvMGb4vgYv2I+1sDkO4jWNnw==}
 
   '@vue/language-core@2.0.21':
     resolution: {integrity: sha512-vjs6KwnCK++kIXT+eI63BGpJHfHNVJcUCr3RnvJsccT3vbJnZV5IhHR2puEkoOkIbDdp0Gqi1wEnv3hEd3WsxQ==}
@@ -4761,10 +4791,6 @@ packages:
     resolution: {integrity: sha512-kbL7ERlqjXubdDd+szuwdlQ1xUxEz9mCz1+m07ftNVStgwRb2RWw+U6oKo08PAvOishMxiqz1mlJyLl8yQx2Qg==}
     engines: {node: '>=16.14.0'}
 
-  ast-kit@1.2.0:
-    resolution: {integrity: sha512-7TnogTQQZEagrHcOcddY0PqXPxVqFoNPPsKoa42Peyc83iinzT+QPKoRLDmzpaUVWZbgqSoHtezsTIoJyyBE+Q==}
-    engines: {node: '>=16.14.0'}
-
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -4886,6 +4912,9 @@ packages:
 
   birpc@0.2.17:
     resolution: {integrity: sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==}
+
+  birpc@0.2.19:
+    resolution: {integrity: sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -8268,6 +8297,9 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
+  ohash@1.1.4:
+    resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -8333,6 +8365,9 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  oxc-parser@0.38.0:
+    resolution: {integrity: sha512-w/cUL64wDb72gaBoOnvodKgHhNF9pDjb2b8gPkDKJDTvIvlbcE9XGDT3cnXOP4N3XCMrRT4MC23bCHGb3gCFSQ==}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -9604,8 +9639,8 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  simple-git@3.26.0:
-    resolution: {integrity: sha512-5tbkCSzuskR6uA7uA23yjasmA0RzugVo8QM2bpsnxkrgP13eisFT7TMS4a+xKEJvbmr4qf+l0WT3eKa9IxxUyw==}
+  simple-git@3.27.0:
+    resolution: {integrity: sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -10637,8 +10672,8 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-vue-inspector@5.2.0:
-    resolution: {integrity: sha512-wWxyb9XAtaIvV/Lr7cqB1HIzmHZFVUJsTNm3yAxkS87dgh/Ky4qr2wDEWNxF23fdhVa3jQ8MZREpr4XyiuaRqA==}
+  vite-plugin-vue-inspector@5.1.3:
+    resolution: {integrity: sha512-pMrseXIDP1Gb38mOevY+BvtNGNqiqmqa2pKB99lnLsADQww9w9xMbAfT4GB6RUoaOkSPrtlXqpq2Fq+Dj2AgFg==}
     peerDependencies:
       vite: ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0
 
@@ -11795,15 +11830,17 @@ snapshots:
   '@babel/helper-create-class-features-plugin@7.23.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.5)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -11820,15 +11857,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.25.0(@babel/core@7.25.2)':
+  '@babel/helper-create-class-features-plugin@7.25.4(@babel/core@7.23.5)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.23.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.24.8
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
+      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.23.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/traverse': 7.25.3
+      '@babel/traverse': 7.25.6
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -11857,7 +11894,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -11901,7 +11938,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
-      '@babel/traverse': 7.25.3
+      '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
@@ -11985,8 +12022,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.8
       '@babel/helper-optimise-call-expression': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.25.0(@babel/core@7.23.5)':
+    dependencies:
+      '@babel/core': 7.23.5
+      '@babel/helper-member-expression-to-functions': 7.24.8
+      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/traverse': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -11995,7 +12041,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-member-expression-to-functions': 7.24.8
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/traverse': 7.25.3
+      '@babel/traverse': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -12010,13 +12056,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
-    dependencies:
-      '@babel/types': 7.25.6
-
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.3
+      '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
@@ -12100,26 +12142,30 @@ snapshots:
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
       '@babel/helper-plugin-utils': 7.24.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-proposal-decorators@7.23.5(@babel/core@7.23.5)':
     dependencies:
@@ -12129,6 +12175,8 @@ snapshots:
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.5)
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -12146,22 +12194,22 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -12176,17 +12224,17 @@ snapshots:
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.23.5)':
+  '@babel/plugin-syntax-import-attributes@7.25.6(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-attributes@7.25.6(@babel/core@7.25.2)':
     dependencies:
@@ -12206,7 +12254,7 @@ snapshots:
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.5)':
     dependencies:
@@ -12216,7 +12264,12 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.23.5)':
+    dependencies:
+      '@babel/core': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -12231,42 +12284,42 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -12282,60 +12335,66 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-async-generator-functions@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.5)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.5)
 
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.23.5)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.23.5)
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-classes@7.23.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.5)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
@@ -12343,88 +12402,88 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/template': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/template': 7.25.0
 
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-for-of@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.5)
 
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.22.5
 
   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.25.2)':
@@ -12441,36 +12500,36 @@ snapshots:
       '@babel/core': 7.23.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.5)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.23.5)':
@@ -12478,52 +12537,58 @@ snapshots:
       '@babel/compat-data': 7.23.5
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.5)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.5)
 
   '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.5)
 
   '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.23.5)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.23.5)
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.5)':
     dependencies:
@@ -12548,13 +12613,13 @@ snapshots:
   '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
   '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-runtime@7.23.4(@babel/core@7.23.5)':
     dependencies:
@@ -12571,28 +12636,30 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-typescript@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -12608,7 +12675,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.25.2)
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.2)
@@ -12618,25 +12685,25 @@ snapshots:
   '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.5)
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/preset-env@7.23.5(@babel/core@7.23.5)':
     dependencies:
@@ -12655,7 +12722,7 @@ snapshots:
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.5)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.5)
       '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.23.5)
-      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.23.5)
+      '@babel/plugin-syntax-import-attributes': 7.25.6(@babel/core@7.23.5)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.5)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.5)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.5)
@@ -12727,7 +12794,7 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/types': 7.25.6
       esutils: 2.0.3
 
@@ -13881,10 +13948,10 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.4.2(magicast@0.3.5)(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)':
+  '@nuxt/devtools-kit@1.6.1(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@4.27.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.22.4)(webpack-sources@3.2.3)
       execa: 7.2.0
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
     transitivePeerDependencies:
@@ -13893,7 +13960,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/devtools-wizard@1.4.2':
+  '@nuxt/devtools-wizard@1.6.1':
     dependencies:
       consola: 3.2.3
       diff: 7.0.0
@@ -13906,14 +13973,14 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.4.2(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
+  '@nuxt/devtools@1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.2(magicast@0.3.5)(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)
-      '@nuxt/devtools-wizard': 1.4.2
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@vue/devtools-core': 7.4.4(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
-      '@vue/devtools-kit': 7.4.4
+      '@nuxt/devtools-kit': 1.6.1(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(webpack-sources@3.2.3)
+      '@nuxt/devtools-wizard': 1.6.1
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@vue/devtools-core': 7.6.4(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
+      '@vue/devtools-kit': 7.6.4
       birpc: 0.2.17
       consola: 3.2.3
       cronstrue: 2.50.0
@@ -13930,20 +13997,20 @@ snapshots:
       local-pkg: 0.5.0
       magicast: 0.3.5
       nypm: 0.3.11
-      ohash: 1.1.3
+      ohash: 1.1.4
       pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.2.0
       rc9: 2.1.2
       scule: 1.3.0
       semver: 7.6.3
-      simple-git: 3.26.0
+      simple-git: 3.27.0
       sirv: 2.0.4
       tinyglobby: 0.2.6
-      unimport: 3.11.1(rollup@4.27.4)(webpack-sources@3.2.3)
+      unimport: 3.12.0(rollup@4.22.4)(webpack-sources@3.2.3)
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
+      vite-plugin-vue-inspector: 5.1.3(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -13954,9 +14021,9 @@ snapshots:
       - vue
       - webpack-sources
 
-  '@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)':
+  '@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/schema': 3.12.2(rollup@4.27.4)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.12.2(rollup@4.22.4)(webpack-sources@3.2.3)
       c12: 1.11.2(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
@@ -13974,7 +14041,7 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.11.1(rollup@4.27.4)(webpack-sources@3.2.3)
+      unimport: 3.11.1(rollup@4.22.4)(webpack-sources@3.2.3)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -14037,8 +14104,9 @@ snapshots:
       - rollup
       - supports-color
       - webpack-sources
+    optional: true
 
-  '@nuxt/schema@3.12.2(rollup@4.27.4)(webpack-sources@3.2.3)':
+  '@nuxt/schema@3.12.2(rollup@4.22.4)(webpack-sources@3.2.3)':
     dependencies:
       compatx: 0.1.8
       consola: 3.2.3
@@ -14050,7 +14118,7 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.11.1(rollup@4.27.4)(webpack-sources@3.2.3)
+      unimport: 3.11.1(rollup@4.22.4)(webpack-sources@3.2.3)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14094,10 +14162,11 @@ snapshots:
       - rollup
       - supports-color
       - webpack-sources
+    optional: true
 
-  '@nuxt/telemetry@2.5.4(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)':
+  '@nuxt/telemetry@2.5.4(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -14120,10 +14189,10 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/vite-builder@3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.27.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
+  '@nuxt/vite-builder@3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.27.4)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
       '@vitejs/plugin-vue': 5.0.5(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))
       autoprefixer: 10.4.19(postcss@8.4.38)
@@ -14146,7 +14215,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.2.0
       postcss: 8.4.38
-      rollup-plugin-visualizer: 5.12.0(rollup@4.27.4)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.22.4)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -14179,6 +14248,32 @@ snapshots:
       - vti
       - vue-tsc
       - webpack-sources
+
+  '@oxc-parser/binding-darwin-arm64@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.38.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.38.0':
+    optional: true
+
+  '@oxc-project/types@0.38.0': {}
 
   '@parcel/watcher-android-arm64@2.4.1':
     optional: true
@@ -14319,13 +14414,6 @@ snapshots:
       magic-string: 0.30.11
     optionalDependencies:
       rollup: 4.22.4
-
-  '@rollup/plugin-replace@5.0.7(rollup@4.27.4)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
-      magic-string: 0.30.11
-    optionalDependencies:
-      rollup: 4.27.4
 
   '@rollup/plugin-terser@0.4.4(rollup@4.22.4)':
     dependencies:
@@ -14561,11 +14649,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 0.7.4
       '@rspack/binding-win32-x64-msvc': 0.7.4
 
-  '@rspack/cli@0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0(esbuild@0.21.5))':
+  '@rspack/cli@0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@rspack/core': 0.7.4(@swc/helpers@0.5.5)
-      '@rspack/dev-server': 0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0(esbuild@0.21.5))
+      '@rspack/dev-server': 0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0)
       colorette: 2.0.19
       exit-hook: 3.2.0
       interpret: 3.1.1
@@ -14592,7 +14680,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.5
 
-  '@rspack/dev-server@0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0(esbuild@0.21.5))':
+  '@rspack/dev-server@0.7.4(@rspack/core@0.7.4(@swc/helpers@0.5.5))(@types/express@4.17.21)(webpack@5.94.0)':
     dependencies:
       '@rspack/core': 0.7.4(@swc/helpers@0.5.5)
       chokidar: 3.5.3
@@ -14600,8 +14688,8 @@ snapshots:
       express: 4.19.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
       mime-types: 2.1.35
-      webpack-dev-middleware: 6.1.2(webpack@5.94.0(esbuild@0.21.5))
-      webpack-dev-server: 4.13.1(webpack@5.94.0(esbuild@0.21.5))
+      webpack-dev-middleware: 6.1.2(webpack@5.94.0)
+      webpack-dev-server: 4.13.1(webpack@5.94.0)
       ws: 8.8.1
     transitivePeerDependencies:
       - '@types/express'
@@ -14656,13 +14744,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0(esbuild@0.21.5))':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0)':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -14674,7 +14762,7 @@ snapshots:
     dependencies:
       solid-js: 1.8.22
 
-  '@solidjs/start@1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
+  '@solidjs/start@1.0.6(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(solid-js@1.8.22)(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))
       '@vinxi/server-components': 0.4.3(vinxi@0.4.3(@types/node@22.7.0)(encoding@0.1.13)(ioredis@5.3.2)(magicast@0.3.5)(terser@5.30.3)(webpack-sources@3.2.3))
@@ -14689,7 +14777,7 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.1
       terracotta: 1.0.5(solid-js@1.8.22)
-      vite-plugin-inspect: 0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
+      vite-plugin-inspect: 0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
       vite-plugin-solid: 2.10.2(solid-js@1.8.22)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -15510,12 +15598,12 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue-macros/common@1.8.0(rollup@4.27.4)(vue@3.5.8(typescript@5.6.2))':
+  '@vue-macros/common@1.8.0(rollup@4.22.4)(vue@3.5.8(typescript@5.6.2))':
     dependencies:
       '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
       '@vue/compiler-sfc': 3.5.5
-      ast-kit: 0.11.3(rollup@4.27.4)
+      ast-kit: 0.11.3(rollup@4.22.4)
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
     optionalDependencies:
@@ -15597,19 +15685,21 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/parser': 7.25.6
-      '@vue/compiler-sfc': 3.5.5
+      '@vue/compiler-sfc': 3.5.8
     transitivePeerDependencies:
       - supports-color
 
   '@vue/babel-plugin-transform-vue-jsx@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
       html-tags: 2.0.0
       lodash.kebabcase: 4.1.1
       svg-tags: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@vue/babel-preset-app@5.0.8(@babel/core@7.23.5)(core-js@3.37.1)(vue@3.4.29(typescript@5.4.5))':
     dependencies:
@@ -15647,55 +15737,61 @@ snapshots:
       '@vue/babel-sugar-v-on': 1.4.0(@babel/core@7.23.5)
     optionalDependencies:
       vue: 3.4.29(typescript@5.4.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vue/babel-sugar-composition-api-inject-h@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
 
   '@vue/babel-sugar-composition-api-render-instance@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
 
   '@vue/babel-sugar-functional-vue@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
 
   '@vue/babel-sugar-inject-h@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
 
   '@vue/babel-sugar-v-model@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
       '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.5)
       camelcase: 5.3.1
       html-tags: 2.0.0
       svg-tags: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@vue/babel-sugar-v-on@1.4.0(@babel/core@7.23.5)':
     dependencies:
       '@babel/core': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.5)
       '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.5)
       camelcase: 5.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(esbuild@0.21.5)(vue@3.4.29(typescript@5.4.5))':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.29(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.23.5
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.23.5)(core-js@3.37.1)(vue@3.4.29(typescript@5.4.5))
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
-      babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.94.0(esbuild@0.21.5))
-      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.21.5))
-      webpack: 5.94.0(esbuild@0.21.5)
+      babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.94.0)
+      thread-loader: 3.0.4(webpack@5.94.0)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - '@swc/core'
       - core-js
@@ -15706,27 +15802,27 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(esbuild@0.21.5)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))':
+  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.23.5
       '@types/webpack-env': 1.18.4
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
-      babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.94.0(esbuild@0.21.5))
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0(esbuild@0.21.5))
+      babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.94.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0)
       globby: 11.1.0
-      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.21.5))
-      ts-loader: 9.5.1(typescript@5.4.5)(webpack@5.94.0(esbuild@0.21.5))
+      thread-loader: 3.0.4(webpack@5.94.0)
+      ts-loader: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript: 5.4.5
       vue: 3.4.29(typescript@5.4.5)
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     optionalDependencies:
       vue-template-compiler: 2.7.15
     transitivePeerDependencies:
@@ -15738,22 +15834,22 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.22.15
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0(esbuild@0.21.5))
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0)
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(esbuild@0.21.5)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.8)(encoding@0.1.13)(lodash@4.17.21)(vue-template-compiler@2.7.15)(vue@3.4.29(typescript@5.4.5))(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.8)(css-loader@6.8.1(webpack@5.94.0(esbuild@0.21.5)))(lodash@4.17.21)(vue-template-compiler@2.7.15)(webpack@5.94.0(esbuild@0.21.5))
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.8)(css-loader@6.8.1(webpack@5.94.0))(lodash@4.17.21)(vue-template-compiler@2.7.15)(webpack@5.94.0)
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.11.3
       acorn-walk: 8.3.2
@@ -15764,9 +15860,9 @@ snapshots:
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.94.0(esbuild@0.21.5))
-      css-loader: 6.8.1(webpack@5.94.0(esbuild@0.21.5))
-      css-minimizer-webpack-plugin: 3.4.1(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5))
+      copy-webpack-plugin: 9.1.0(webpack@5.94.0)
+      css-loader: 6.8.1(webpack@5.94.0)
+      css-minimizer-webpack-plugin: 3.4.1(webpack@5.94.0)
       cssnano: 5.1.15(postcss@8.4.32)
       debug: 4.3.4
       default-gateway: 6.0.3
@@ -15775,27 +15871,27 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.5.3(webpack@5.94.0(esbuild@0.21.5))
+      html-webpack-plugin: 5.5.3(webpack@5.94.0)
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.6.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.7.6(webpack@5.94.0(esbuild@0.21.5))
+      mini-css-extract-plugin: 2.7.6(webpack@5.94.0)
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
       postcss: 8.4.32
-      postcss-loader: 6.2.1(postcss@8.4.32)(webpack@5.94.0(esbuild@0.21.5))
-      progress-webpack-plugin: 1.0.16(webpack@5.94.0(esbuild@0.21.5))
+      postcss-loader: 6.2.1(postcss@8.4.32)(webpack@5.94.0)
+      progress-webpack-plugin: 1.0.16(webpack@5.94.0)
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5))
-      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.21.5))
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.4.5))(webpack@5.94.0(esbuild@0.21.5))
+      terser-webpack-plugin: 5.3.9(webpack@5.94.0)
+      thread-loader: 3.0.4(webpack@5.94.0)
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.4.5))(webpack@5.94.0)
       vue-style-loader: 4.1.3
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
       webpack-bundle-analyzer: 4.10.1
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.1(debug@4.3.4)(webpack@5.94.0(esbuild@0.21.5))
+      webpack-dev-server: 4.15.1(debug@4.3.4)(webpack@5.94.0)
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.19
@@ -16099,10 +16195,10 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.3.8
 
-  '@vue/devtools-core@7.4.4(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))':
+  '@vue/devtools-core@7.6.4(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))':
     dependencies:
-      '@vue/devtools-kit': 7.4.4
-      '@vue/devtools-shared': 7.4.5
+      '@vue/devtools-kit': 7.6.4
+      '@vue/devtools-shared': 7.6.7
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
@@ -16121,10 +16217,10 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.1
 
-  '@vue/devtools-kit@7.4.4':
+  '@vue/devtools-kit@7.6.4':
     dependencies:
-      '@vue/devtools-shared': 7.4.5
-      birpc: 0.2.17
+      '@vue/devtools-shared': 7.6.7
+      birpc: 0.2.19
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
@@ -16135,7 +16231,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-shared@7.4.5':
+  '@vue/devtools-shared@7.6.7':
     dependencies:
       rfdc: 1.4.1
 
@@ -16154,10 +16250,10 @@ snapshots:
   '@vue/language-core@2.0.21(typescript@5.6.2)':
     dependencies:
       '@volar/language-core': 2.3.0
-      '@vue/compiler-dom': 3.4.21
-      '@vue/shared': 3.4.21
+      '@vue/compiler-dom': 3.5.8
+      '@vue/shared': 3.5.8
       computeds: 0.0.1
-      minimatch: 9.0.4
+      minimatch: 9.0.5
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.15
     optionalDependencies:
@@ -16551,35 +16647,30 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@0.11.3(rollup@4.27.4):
+  ast-kit@0.11.3(rollup@4.22.4):
     dependencies:
       '@babel/parser': 7.25.6
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
 
-  ast-kit@0.9.5(rollup@4.27.4):
+  ast-kit@0.9.5(rollup@4.22.4):
     dependencies:
       '@babel/parser': 7.25.6
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
-
-  ast-kit@1.2.0:
-    dependencies:
-      '@babel/parser': 7.25.6
-      pathe: 1.1.2
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.6.3
 
-  ast-walker-scope@0.5.0(rollup@4.27.4):
+  ast-walker-scope@0.5.0(rollup@4.22.4):
     dependencies:
       '@babel/parser': 7.25.6
-      ast-kit: 0.9.5(rollup@4.27.4)
+      ast-kit: 0.9.5(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
 
@@ -16783,14 +16874,14 @@ snapshots:
 
   b4a@1.6.4: {}
 
-  babel-loader@8.3.0(@babel/core@7.23.5)(webpack@5.94.0(esbuild@0.21.5)):
+  babel-loader@8.3.0(@babel/core@7.23.5)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.23.5
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -16855,6 +16946,8 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   birpc@0.2.17: {}
+
+  birpc@0.2.19: {}
 
   bl@4.1.0:
     dependencies:
@@ -17254,7 +17347,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       acorn: 8.12.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -17374,7 +17467,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@9.1.0(webpack@5.94.0(esbuild@0.21.5)):
+  copy-webpack-plugin@9.1.0(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -17382,7 +17475,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   core-js-compat@3.35.0:
     dependencies:
@@ -17457,7 +17550,7 @@ snapshots:
     dependencies:
       postcss: 8.4.39
 
-  css-loader@6.8.1(webpack@5.94.0(esbuild@0.21.5)):
+  css-loader@6.8.1(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -17467,9 +17560,9 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.47)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
-  css-minimizer-webpack-plugin@3.4.1(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5)):
+  css-minimizer-webpack-plugin@3.4.1(webpack@5.94.0):
     dependencies:
       cssnano: 5.1.15(postcss@8.4.47)
       jest-worker: 27.5.1
@@ -17477,9 +17570,7 @@ snapshots:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.94.0(esbuild@0.21.5)
-    optionalDependencies:
-      esbuild: 0.21.5
+      webpack: 5.94.0
 
   css-select@4.3.0:
     dependencies:
@@ -18490,7 +18581,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esutils@2.0.3: {}
 
@@ -18774,7 +18865,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0(esbuild@0.21.5)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.11.1(jiti@1.21.6))(typescript@5.4.5)(vue-template-compiler@2.7.15)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.23.5
       '@types/json-schema': 7.0.15
@@ -18790,7 +18881,7 @@ snapshots:
       semver: 7.6.3
       tapable: 1.1.3
       typescript: 5.4.5
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     optionalDependencies:
       eslint: 9.11.1(jiti@1.21.6)
       vue-template-compiler: 2.7.15
@@ -19281,14 +19372,14 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.5.3(webpack@5.94.0(esbuild@0.21.5)):
+  html-webpack-plugin@5.5.3(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   htmlparser2@6.1.0:
     dependencies:
@@ -19555,11 +19646,11 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-ssh@1.4.0:
     dependencies:
@@ -20678,10 +20769,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.7.6(webpack@5.94.0(esbuild@0.21.5)):
+  mini-css-extract-plugin@2.7.6(webpack@5.94.0):
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   minimalistic-assert@1.0.1: {}
 
@@ -20813,7 +20904,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@14.2.4(@babel/core@7.23.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -20823,7 +20914,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.23.5)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -21024,14 +21115,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.27.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3):
+  nuxt@3.12.2(@parcel/watcher@2.4.1)(@types/node@22.7.0)(encoding@0.1.13)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.3.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue-tsc@2.0.21(typescript@5.6.2))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.2(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
-      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.12.2(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@nuxt/telemetry': 2.5.4(magicast@0.3.5)(rollup@4.27.4)(webpack-sources@3.2.3)
-      '@nuxt/vite-builder': 3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.27.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+      '@nuxt/devtools': 1.6.1(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.12.2(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/telemetry': 2.5.4(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/vite-builder': 3.12.2(@types/node@22.7.0)(eslint@9.11.1(jiti@1.21.6))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.4)(terser@5.30.3)(typescript@5.6.2)(vue-tsc@2.0.21(typescript@5.6.2))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
       '@unhead/dom': 1.9.14
       '@unhead/ssr': 1.9.14
       '@unhead/vue': 1.9.14(vue@3.5.8(typescript@5.6.2))
@@ -21074,9 +21165,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1(webpack-sources@3.2.3)
       unenv: 1.9.0
-      unimport: 3.7.2(rollup@4.27.4)(webpack-sources@3.2.3)
+      unimport: 3.7.2(rollup@4.22.4)(webpack-sources@3.2.3)
       unplugin: 1.14.1(webpack-sources@3.2.3)
-      unplugin-vue-router: 0.7.0(rollup@4.27.4)(vue-router@4.3.3(vue@3.5.8(typescript@5.6.2)))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
+      unplugin-vue-router: 0.7.0(rollup@4.22.4)(vue-router@4.3.3(vue@3.5.8(typescript@5.6.2)))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3)
       unstorage: 1.10.2(ioredis@5.3.2)
       untyped: 1.4.2
       vue: 3.5.8(typescript@5.6.2)
@@ -21180,6 +21271,8 @@ snapshots:
 
   ohash@1.1.3: {}
 
+  ohash@1.1.4: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -21281,6 +21374,19 @@ snapshots:
       strip-ansi: 7.1.0
 
   os-tmpdir@1.0.2: {}
+
+  oxc-parser@0.38.0:
+    dependencies:
+      '@oxc-project/types': 0.38.0
+    optionalDependencies:
+      '@oxc-parser/binding-darwin-arm64': 0.38.0
+      '@oxc-parser/binding-darwin-x64': 0.38.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.38.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.38.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.38.0
+      '@oxc-parser/binding-linux-x64-musl': 0.38.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.38.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.38.0
 
   p-finally@1.0.0: {}
 
@@ -21445,7 +21551,7 @@ snapshots:
 
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
@@ -21653,13 +21759,13 @@ snapshots:
       postcss: 8.4.49
     optional: true
 
-  postcss-loader@6.2.1(postcss@8.4.32)(webpack@5.94.0(esbuild@0.21.5)):
+  postcss-loader@6.2.1(postcss@8.4.32)(webpack@5.94.0):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.32
       semver: 7.6.3
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   postcss-merge-longhand@5.1.7(postcss@8.4.32):
     dependencies:
@@ -22258,12 +22364,12 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.94.0(esbuild@0.21.5)):
+  progress-webpack-plugin@1.0.16(webpack@5.94.0):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   prompts@2.4.2:
     dependencies:
@@ -22677,15 +22783,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.4
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.27.4):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 4.27.4
-
   rollup@3.29.4:
     optionalDependencies:
       fsevents: 2.3.3
@@ -23043,7 +23140,7 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
-  simple-git@3.26.0:
+  simple-git@3.27.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
@@ -23295,12 +23392,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.0
 
-  styled-jsx@5.1.1(@babel/core@7.23.5)(react@18.3.1):
+  styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.23.5
 
   stylehacks@5.1.1(postcss@8.4.32):
     dependencies:
@@ -23391,7 +23486,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       acorn: 8.12.1
       aria-query: 5.3.0
       axobject-query: 4.0.0
@@ -23486,27 +23581,23 @@ snapshots:
       solid-js: 1.8.22
       solid-use: 0.8.0(solid-js@1.8.22)
 
-  terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5)):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.30.3
-      webpack: 5.94.0(esbuild@0.21.5)
-    optionalDependencies:
-      esbuild: 0.21.5
+      webpack: 5.94.0
 
-  terser-webpack-plugin@5.3.9(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5)):
+  terser-webpack-plugin@5.3.9(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.94.0(esbuild@0.21.5)
-    optionalDependencies:
-      esbuild: 0.21.5
+      webpack: 5.94.0
 
   terser@5.24.0:
     dependencies:
@@ -23532,14 +23623,14 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thread-loader@3.0.4(webpack@5.94.0(esbuild@0.21.5)):
+  thread-loader@3.0.4(webpack@5.94.0):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   thunky@1.1.0: {}
 
@@ -23599,7 +23690,7 @@ snapshots:
     dependencies:
       typescript: 5.6.2
 
-  ts-loader@9.5.1(typescript@5.4.5)(webpack@5.94.0(esbuild@0.21.5)):
+  ts-loader@9.5.1(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.0
@@ -23607,7 +23698,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.4.5
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
   tsconfck@3.0.0(typescript@5.6.2):
     optionalDependencies:
@@ -23679,7 +23770,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.2:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.3
 
   typescript@5.4.5: {}
 
@@ -23803,9 +23894,9 @@ snapshots:
       trough: 2.1.0
       vfile: 6.0.1
 
-  unimport@3.11.1(rollup@4.27.4)(webpack-sources@3.2.3):
+  unimport@3.11.1(rollup@4.22.4)(webpack-sources@3.2.3):
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -23859,29 +23950,11 @@ snapshots:
     transitivePeerDependencies:
       - rollup
       - webpack-sources
+    optional: true
 
   unimport@3.7.2(rollup@4.22.4)(webpack-sources@3.2.3):
     dependencies:
       '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
-      acorn: 8.12.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - rollup
-      - webpack-sources
-
-  unimport@3.7.2(rollup@4.27.4)(webpack-sources@3.2.3):
-    dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -23998,12 +24071,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-router@0.7.0(rollup@4.27.4)(vue-router@4.3.3(vue@3.5.8(typescript@5.6.2)))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3):
+  unplugin-vue-router@0.7.0(rollup@4.22.4)(vue-router@4.3.3(vue@3.5.8(typescript@5.6.2)))(vue@3.5.8(typescript@5.6.2))(webpack-sources@3.2.3):
     dependencies:
       '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
-      '@vue-macros/common': 1.8.0(rollup@4.27.4)(vue@3.5.8(typescript@5.6.2))
-      ast-walker-scope: 0.5.0(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
+      '@vue-macros/common': 1.8.0(rollup@4.22.4)(vue@3.5.8(typescript@5.6.2))
+      ast-walker-scope: 0.5.0(rollup@4.22.4)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -24290,6 +24363,24 @@ snapshots:
       typescript: 5.6.2
       vue-tsc: 2.0.21(typescript@5.6.2)
 
+  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.3(rollup@4.22.4)
+      debug: 4.3.7
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.2.0
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 3.0.0
+      vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
+    optionalDependencies:
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -24302,24 +24393,6 @@ snapshots:
       picocolors: 1.1.1
       sirv: 3.0.0
       vite: 6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)
-    optionalDependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.10.1(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
-      debug: 4.3.7
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 3.0.0
-      vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
     transitivePeerDependencies:
@@ -24362,10 +24435,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
+  vite-plugin-inspect@0.7.42(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@6.0.1(@types/node@22.7.0)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
       debug: 4.3.7
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -24379,10 +24452,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.27.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3))(rollup@4.22.4)(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
       debug: 4.3.7
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -24410,7 +24483,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.2.0(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
+  vite-plugin-vue-inspector@5.1.3(vite@5.4.1(@types/node@22.7.0)(terser@5.30.3)):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.25.2)
@@ -24418,7 +24491,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.25.2)
-      '@vue/compiler-dom': 3.5.5
+      '@vue/compiler-dom': 3.5.8
       kolorist: 1.8.0
       magic-string: 0.30.11
       vite: 5.4.1(@types/node@22.7.0)(terser@5.30.3)
@@ -24697,15 +24770,15 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.5.8)(css-loader@6.8.1(webpack@5.94.0(esbuild@0.21.5)))(lodash@4.17.21)(vue-template-compiler@2.7.15)(webpack@5.94.0(esbuild@0.21.5)):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.5.8)(css-loader@6.8.1(webpack@5.94.0))(lodash@4.17.21)(vue-template-compiler@2.7.15)(webpack@5.94.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)
-      css-loader: 6.8.1(webpack@5.94.0(esbuild@0.21.5))
+      css-loader: 6.8.1(webpack@5.94.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.8
       vue-template-compiler: 2.7.15
@@ -24764,22 +24837,22 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.4.5))(webpack@5.94.0(esbuild@0.21.5)):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.4.5))(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.8
       vue: 3.4.29(typescript@5.4.5)
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.6.2))(webpack@5.94.0(esbuild@0.21.5)):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.8)(vue@3.4.29(typescript@5.6.2))(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.8
       vue: 3.4.29(typescript@5.6.2)
@@ -24816,7 +24889,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 2.3.0
       '@vue/language-core': 2.0.21(typescript@5.6.2)
-      semver: 7.6.0
+      semver: 7.6.3
       typescript: 5.6.2
     optional: true
 
@@ -24923,16 +24996,16 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.94.0(esbuild@0.21.5)):
+  webpack-dev-middleware@5.3.3(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
-  webpack-dev-middleware@6.1.2(webpack@5.94.0(esbuild@0.21.5)):
+  webpack-dev-middleware@6.1.2(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -24940,9 +25013,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
 
-  webpack-dev-server@4.13.1(webpack@5.94.0(esbuild@0.21.5)):
+  webpack-dev-server@4.13.1(webpack@5.94.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -24972,17 +25045,17 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.94.0(esbuild@0.21.5))
+      webpack-dev-middleware: 5.3.3(webpack@5.94.0)
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.1(debug@4.3.4)(webpack@5.94.0(esbuild@0.21.5)):
+  webpack-dev-server@4.15.1(debug@4.3.4)(webpack@5.94.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -25012,10 +25085,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.94.0(esbuild@0.21.5))
+      webpack-dev-middleware: 5.3.3(webpack@5.94.0)
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.21.5)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -25034,7 +25107,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0(esbuild@0.21.5):
+  webpack@5.94.0:
     dependencies:
       '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
@@ -25056,7 +25129,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.94.0(esbuild@0.21.5))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -8,7 +8,6 @@ const DEFAULT_OPTIONS: Options = {
   disableHighlight: false,
   disablePassLogs: false,
   extendedPathFileNames: [],
-  babelParserPlugins: ['typescript', 'jsx'],
   port: 3070,
   silent: false,
 }
@@ -20,14 +19,6 @@ export const BUILD_OPTIONS: Options = {
 }
 
 export function resolveOptions(options: Options): Options {
-  // merge babel parser plugins
-  if (options.babelParserPlugins) {
-    options.babelParserPlugins = [
-      ...DEFAULT_OPTIONS.babelParserPlugins!,
-      ...options.babelParserPlugins,
-    ]
-  }
-
   let resolved = {
     ...DEFAULT_OPTIONS,
     ...options,

--- a/src/core/transform/compilers/svelte.ts
+++ b/src/core/transform/compilers/svelte.ts
@@ -5,16 +5,17 @@ export async function svelteCompiler(context: Context): Promise<CompileResult> {
   try {
     const { code } = context
 
-    const scriptRegex = /<script(?:\s+lang="\w+")?>([\s\S]*?)<\/script>/
+    const scriptRegex = /<script(?:\s+lang="(\w+)")?>([\s\S]*?)<\/script>/
 
     const match = scriptRegex.exec(code)
     if (match) {
-      const content = match[1]
+      const lang = match[1]
+      const content = match[2]
       const offset = code.indexOf(content)
       const line = offset ? code.substring(0, offset).split('\n').length - 1 : 0
-
       return {
         script: content,
+        scriptLang: lang,
         offset,
         line,
       }

--- a/src/core/transform/compilers/svelte.ts
+++ b/src/core/transform/compilers/svelte.ts
@@ -1,4 +1,4 @@
-import type { CompileResult, Context } from '../../../types'
+import type { CompileResult, Context, Lang } from '../../../types'
 import { PLUGIN_NAME } from './../../constants'
 
 export async function svelteCompiler(context: Context): Promise<CompileResult> {
@@ -9,13 +9,13 @@ export async function svelteCompiler(context: Context): Promise<CompileResult> {
 
     const match = scriptRegex.exec(code)
     if (match) {
-      const lang = match[1]
+      const lang = match[1] || 'js'
       const content = match[2]
       const offset = code.indexOf(content)
       const line = offset ? code.substring(0, offset).split('\n').length - 1 : 0
       return {
         script: content,
-        scriptLang: lang,
+        lang: lang as Lang,
         offset,
         line,
       }
@@ -23,6 +23,7 @@ export async function svelteCompiler(context: Context): Promise<CompileResult> {
 
     return {
       script: '',
+      lang: 'js',
       offset: 0,
       line: 0,
     }
@@ -31,6 +32,7 @@ export async function svelteCompiler(context: Context): Promise<CompileResult> {
     console.error(`${PLUGIN_NAME}:${error}`)
     return {
       script: '',
+      lang: 'js',
       offset: 0,
       line: 0,
     }

--- a/src/core/transform/compilers/vanilla.ts
+++ b/src/core/transform/compilers/vanilla.ts
@@ -1,8 +1,14 @@
-import type { CompileResult, Context } from '../../../types'
+import type { CompileResult, Context, Lang } from '../../../types'
+import { extname } from 'pathe'
 
 export async function vanillaCompiler(context: Context): Promise<CompileResult> {
+  const { code, id } = context
+  const urlObject = new URL(id, 'file://')
+  const fileType = extname(urlObject.pathname)
+
   return {
-    script: context.code,
+    script: code,
+    lang: fileType.replace('.', '') as Lang,
     offset: 0,
     line: 0,
   }

--- a/src/core/transform/compilers/vue3.ts
+++ b/src/core/transform/compilers/vue3.ts
@@ -1,4 +1,4 @@
-import type { CompileResult, Context } from '../../../types'
+import type { CompileResult, Context, Lang } from '../../../types'
 import { PLUGIN_NAME } from '../../constants'
 
 export async function vue3Compiler(context: Context): Promise<CompileResult> {
@@ -6,11 +6,11 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
     const { code, id } = context
     const { parse } = await import('vue/compiler-sfc')
 
-    const compileResults = {
+    const compileResults: CompileResult = {
       script: '',
       line: 0,
       offset: 0,
-      scriptLang: '',
+      lang: 'js',
     }
 
     const { descriptor, errors } = parse(code, {
@@ -20,7 +20,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
     if (errors.length === 0) {
       if (descriptor.script) {
         compileResults.script = descriptor.script.content
-        compileResults.scriptLang = descriptor.script.lang || 'js'
+        compileResults.lang = (descriptor.script.lang as Lang)
         const { line, offset } = descriptor.script.loc.start
         compileResults.line = line - 1
         compileResults.offset = offset
@@ -29,7 +29,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
       else if (descriptor.scriptSetup) {
         compileResults.script = descriptor.scriptSetup.content
         const { line, offset } = descriptor.scriptSetup.loc.start
-        compileResults.scriptLang = descriptor.scriptSetup.lang || 'js'
+        compileResults.lang = (descriptor.scriptSetup.lang as Lang)
         compileResults.line = line - 1
         compileResults.offset = offset
       }
@@ -41,6 +41,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
     console.error(`[${PLUGIN_NAME}]`, error)
     return {
       script: '',
+      lang: 'js',
       offset: 0,
       line: 0,
     }

--- a/src/core/transform/compilers/vue3.ts
+++ b/src/core/transform/compilers/vue3.ts
@@ -10,6 +10,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
       script: '',
       line: 0,
       offset: 0,
+      scriptLang: '',
     }
 
     const { descriptor, errors } = parse(code, {
@@ -19,6 +20,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
     if (errors.length === 0) {
       if (descriptor.script) {
         compileResults.script = descriptor.script.content
+        compileResults.scriptLang = descriptor.script.lang || 'js'
         const { line, offset } = descriptor.script.loc.start
         compileResults.line = line - 1
         compileResults.offset = offset
@@ -27,6 +29,7 @@ export async function vue3Compiler(context: Context): Promise<CompileResult> {
       else if (descriptor.scriptSetup) {
         compileResults.script = descriptor.scriptSetup.content
         const { line, offset } = descriptor.scriptSetup.loc.start
+        compileResults.scriptLang = descriptor.scriptSetup.lang || 'js'
         compileResults.line = line - 1
         compileResults.offset = offset
       }

--- a/src/core/utils/codegen.ts
+++ b/src/core/utils/codegen.ts
@@ -78,7 +78,7 @@ export function genConsoleString(genContext: GenContext) {
     argsName = `${argsName.slice(0, 30)}...`
 
   // not output when argtype is string or number
-  const lineInfo = `%c${builtInThemes.highlight.icon} ${fileName}\u00B7${originalLine}${['StringLiteral', 'NumericLiteral'].includes(argType) ? '' : ` ~ ${argsName}`}`
+  const lineInfo = `%c${builtInThemes.highlight.icon} ${fileName}\u00B7${originalLine}${['Literal'].includes(argType) ? '' : ` ~ ${argsName}`}`
   const codePosition = `${filePathMapString},${originalLine},${(originalColumn || 0) + 1}`
 
   const launchEditorString = `%c${builtInThemes.launchEditor.icon} http://127.1:${port}#${codePosition}`

--- a/src/core/utils/common.ts
+++ b/src/core/utils/common.ts
@@ -1,5 +1,6 @@
-import type { Comment, Expression } from 'oxc-parser'
+import type { Comment } from 'oxc-parser'
 import type { Compiler, Options } from '../../types'
+import type { Node } from '../utils/walker'
 import { createFilter } from '@rollup/pluginutils'
 import { extname } from 'pathe'
 import { PLUGIN_NAME } from '../constants'
@@ -89,7 +90,7 @@ export function isPluginDisable(meta: {
   return false
 }
 
-export function isConsoleExpression(node: Expression) {
+export function isConsoleExpression(node: Node) {
   return node.type === 'CallExpression'
     && node.callee.type === 'StaticMemberExpression' as unknown as string
     && (node.callee as any).object.type === 'Identifier'

--- a/src/core/utils/walker.ts
+++ b/src/core/utils/walker.ts
@@ -1,0 +1,24 @@
+// Ref: https://github.com/danielroe/oxc-walker/blob/main/src/index.ts
+import type { Node as ESTreeNode, Program as ESTreeProgram } from 'estree'
+import type { SyncHandler } from 'estree-walker'
+
+import type { CatchClause, ClassBody, Declaration, ExportSpecifier, Expression, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, MagicString, MethodDefinition, ModuleDeclaration, ObjectProperty, ParseResult, Pattern, PrivateIdentifier, Program, PropertyDefinition, SpreadElement, Statement, Super, SwitchCase, TemplateElement } from 'oxc-parser'
+
+import { walk as _walk } from 'estree-walker'
+
+/** estree also has AssignmentProperty, Identifier and Literal as possible node types */
+export type Node = Declaration | Expression | ClassBody | CatchClause | MethodDefinition | ModuleDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | Pattern | PrivateIdentifier | Program | SpreadElement | Statement | Super | SwitchCase | TemplateElement | ObjectProperty | PropertyDefinition
+
+type WalkerCallback = (this: ThisParameterType<SyncHandler>, node: Node, parent: Node | null, ctx: { key: string | number | symbol | null | undefined, index: number | null | undefined, ast: Program | Node, magicString?: MagicString | undefined }) => void
+
+export function walk(input: Program | Node | ParseResult, callback: { enter?: WalkerCallback, leave?: WalkerCallback }) {
+  const [ast, magicString] = 'magicString' in input ? [input.program, input.magicString] : [input]
+  return _walk(ast as unknown as ESTreeProgram | ESTreeNode, {
+    enter(node, parent, key, index) {
+      callback.enter?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString })
+    },
+    leave(node, parent, key, index) {
+      callback.leave?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString })
+    },
+  }) as Program | Node | null
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,7 @@ export interface Context {
 
 export interface CompileResult {
   script: string
+  scriptLang?: string
   offset: number
   line: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { ParserPlugin } from '@babel/parser'
-
 export interface Options {
   /**
    * Add a string prefix to the console log.
@@ -61,13 +59,10 @@ export interface Options {
   specifiedEditor?: string | undefined
 
   /**
-   * Babel parser plugins. `typescript` and `jsx` are enabled by default.
    *
-   * https://babeljs.io/docs/en/babel-parser#plugins
-   *
-   * @defaultValue ['typescript', 'jsx']
+   * @deprecated This option has been removed since v1.11.0 and will be deleted on next major version.
    */
-  babelParserPlugins?: ParserPlugin[]
+  babelParserPlugins?: never
 
   /**
    * Whether to disable pass logs feature.

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,9 +97,11 @@ export interface Context {
   options: Options
 }
 
+export type Lang = 'js' | 'jsx' | 'ts' | 'tsx' | undefined
+
 export interface CompileResult {
   script: string
-  scriptLang?: string
+  lang: Lang
   offset: number
   line: number
 }

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -88,18 +88,20 @@ exports[`svelte transform > svelte 1`] = `
 }
 `;
 
-exports[`utf-8 > on top of file 1`] = `
+exports[`utf-8 > includes utf-8 1`] = `
 {
-  "code": "console.log("%c🚀 main.js·1%c🔦 http://127.1:3070#mainjs,1,1",\`padding:2px 5px;border-radius:3px 0 0 3px;margin:0 0 5px 0;color:#111827;background:\${globalThis._UTC_DETECT_DARK && globalThis._UTC_DETECT_DARK() ? '#F7DF1E90;' : '#F7DF1E;'}\`,\`background:#00DC8250;padding:2px 5px;border-radius:0 3px 3px 0;margin:0 0 5px 0;\`,"\\n",'你好，世界！')",
+  "code": "const a = '你好' 
+console.log("%c🚀 main.js·2 ~ a%c🔦 http://127.1:3070#mainjs,2,1",\`padding:2px 5px;border-radius:3px 0 0 3px;margin:0 0 5px 0;color:#111827;background:\${globalThis._UTC_DETECT_DARK && globalThis._UTC_DETECT_DARK() ? '#F7DF1E90;' : '#F7DF1E;'}\`,\`background:#00DC8250;padding:2px 5px;border-radius:0 3px 3px 0;margin:0 0 5px 0;\`,"\\n",a)",
   "map": SourceMap {
     "file": "main.js",
-    "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,6TAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC",
+    "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACf,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,iUAAC,CAAC",
     "names": [],
     "sources": [
       "main.js",
     ],
     "sourcesContent": [
-      "console.log('你好，世界！')",
+      "const a = '你好' 
+console.log(a)",
     ],
     "version": 3,
   },

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -88,6 +88,24 @@ exports[`svelte transform > svelte 1`] = `
 }
 `;
 
+exports[`utf-8 > on top of file 1`] = `
+{
+  "code": "console.log("%c🚀 main.js·1%c🔦 http://127.1:3070#mainjs,1,1",\`padding:2px 5px;border-radius:3px 0 0 3px;margin:0 0 5px 0;color:#111827;background:\${globalThis._UTC_DETECT_DARK && globalThis._UTC_DETECT_DARK() ? '#F7DF1E90;' : '#F7DF1E;'}\`,\`background:#00DC8250;padding:2px 5px;border-radius:0 3px 3px 0;margin:0 0 5px 0;\`,"\\n",'你好，世界！')",
+  "map": SourceMap {
+    "file": "main.js",
+    "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,6TAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC",
+    "names": [],
+    "sources": [
+      "main.js",
+    ],
+    "sourcesContent": [
+      "console.log('你好，世界！')",
+    ],
+    "version": 3,
+  },
+}
+`;
+
 exports[`vanilla transform > tsx 1`] = `
 {
   "code": ""use client";

--- a/test/fixtures/transform.ts
+++ b/test/fixtures/transform.ts
@@ -100,3 +100,9 @@ export const WIN_PATH = {
 `,
   id: '\\home\\runner\\App.vue',
 }
+
+export const UTF_8 = {
+  options: {},
+  code: `console.log('你好，世界！')`,
+  id: '/home/runner/main.js',
+}

--- a/test/fixtures/transform.ts
+++ b/test/fixtures/transform.ts
@@ -103,6 +103,7 @@ export const WIN_PATH = {
 
 export const UTF_8 = {
   options: {},
-  code: `console.log('你好，世界！')`,
+  code: `const a = '你好' 
+console.log(a)`,
   id: '/home/runner/main.js',
 }

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -80,38 +80,6 @@ describe('resolve options', () => {
   it('empty', () => {
     expect(resolveOptions({})).toMatchInlineSnapshot(`
       {
-        "babelParserPlugins": [
-          "typescript",
-          "jsx",
-        ],
-        "disableHighlight": false,
-        "disableLaunchEditor": false,
-        "disablePassLogs": false,
-        "extendedPathFileNames": [],
-        "port": 3070,
-        "prefix": "",
-        "silent": false,
-        "suffix": "",
-      }
-    `)
-  })
-
-  it('babel parser plugins', () => {
-    expect(resolveOptions({
-      babelParserPlugins: ['importAttributes', ['optionalChainingAssign', { version: '2023-07' }]],
-    })).toMatchInlineSnapshot(`
-      {
-        "babelParserPlugins": [
-          "typescript",
-          "jsx",
-          "importAttributes",
-          [
-            "optionalChainingAssign",
-            {
-              "version": "2023-07",
-            },
-          ],
-        ],
         "disableHighlight": false,
         "disableLaunchEditor": false,
         "disablePassLogs": false,

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -2,7 +2,8 @@ import { join } from 'pathe'
 import { describe, expect, it, vi } from 'vitest'
 import { resolveOptions } from '../src/core/options'
 import { transform } from '../src/core/transform'
-import { INCLUDES_HIGHLIGHT, SVELTE, TSX, TYPESCRIPT, VUE_OPTIONS, VUE_SCRIPT_SETUP, WIN_PATH } from './fixtures/transform'
+import { COMMENT_TOP_FILE } from './fixtures/comments'
+import { INCLUDES_HIGHLIGHT, SVELTE, TSX, TYPESCRIPT, UTF_8, VUE_OPTIONS, VUE_SCRIPT_SETUP, WIN_PATH } from './fixtures/transform'
 
 vi.mock('node:process', () => {
   return {
@@ -62,5 +63,12 @@ describe('edge case', () => {
   it('win path', async () => {
     WIN_PATH.options = resolveOptions(WIN_PATH.options)
     expect(await transform(WIN_PATH)).matchSnapshot()
+  })
+})
+
+describe('utf-8', () => {
+  it('on top of file', async () => {
+    UTF_8.options = resolveOptions(UTF_8.options)
+    expect(await transform(UTF_8)).toMatchSnapshot()
   })
 })

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -2,7 +2,6 @@ import { join } from 'pathe'
 import { describe, expect, it, vi } from 'vitest'
 import { resolveOptions } from '../src/core/options'
 import { transform } from '../src/core/transform'
-import { COMMENT_TOP_FILE } from './fixtures/comments'
 import { INCLUDES_HIGHLIGHT, SVELTE, TSX, TYPESCRIPT, UTF_8, VUE_OPTIONS, VUE_SCRIPT_SETUP, WIN_PATH } from './fixtures/transform'
 
 vi.mock('node:process', () => {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -66,7 +66,7 @@ describe('edge case', () => {
 })
 
 describe('utf-8', () => {
-  it('on top of file', async () => {
+  it('includes utf-8', async () => {
     UTF_8.options = resolveOptions(UTF_8.options)
     expect(await transform(UTF_8)).toMatchSnapshot()
   })


### PR DESCRIPTION
### Description
Use `oxc-parser` to replace `@babel/parser`. 


### Linked Issues

#48 

### Additional context

Wait the upstream issue to be resolved:

- oxc-project/oxc#7508