### PR TITLE
fix: compatible with vue-loader experimentalInlineMatchResource

### DIFF
--- a/src/core/utils/common.ts
+++ b/src/core/utils/common.ts
@@ -6,7 +6,7 @@ import { extname } from 'pathe'
 import { PLUGIN_NAME } from '../constants'
 
 export const filter = createFilter(
-  [/\.vue$/, /\.vue\?vue/, /\.vue\?v=/, /\.ts$/, /\.tsx$/, /\.js$/, /\.jsx$/, /\.svelte$/, /\.astro$/],
+  [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.vue\?v=/, /\.ts$/, /\.tsx$/, /\.js$/, /\.jsx$/, /\.svelte$/, /\.astro$/],
   [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 )
 

--- a/src/core/utils/common.ts
+++ b/src/core/utils/common.ts
@@ -6,7 +6,7 @@ import { extname } from 'pathe'
 import { PLUGIN_NAME } from '../constants'
 
 export const filter = createFilter(
-  [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.vue\?v=/, /\.ts$/, /\.tsx$/, /\.js$/, /\.jsx$/, /\.svelte$/, /\.astro$/],
+  [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.vue\?v=/, /\.ts$/, /\.tsx$/, /\.js$/, /\.jsx$/, /\.svelte$/, /\.astro$/],
   [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 )
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


When using vue-loader experimentalInlineMatchResource, the request will have an additional .js/.ts extension to match the js/ts module rule

```diff
// without experimentalInlineMatchResource
- src/App.vue?vue&type=script&setup=true&lang=ts
// with experimentalInlineMatchResource
+ src/App.vue.ts?vue&type=script&setup=true&lang=ts
```

But the default include RegExps failed to match the request


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
